### PR TITLE
Support a "charge limit" number

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -157,6 +157,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         else:
             LOGGER.debug("Charging data not available.")
 
+
         # Determine if the vehicle is powered on
         self.is_powered_on = False
         status_data = data.get("status")

--- a/custom_components/mg_saic/number.py
+++ b/custom_components/mg_saic/number.py
@@ -1,6 +1,7 @@
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent
+from saic_ismart_client_ng.api.vehicle_charging.schema import ChargeCurrentLimitCode
 from .const import DOMAIN, LOGGER
 
 
@@ -21,8 +22,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # Check if the vehicle supports setting Target SOC
     vehicle_type = coordinator.vehicle_type
     if vehicle_type in ["BEV", "PHEV"]:
+        target_soc_number = SAICMGTargetSOCNumber(coordinator, client, vin_info, vin)
+        number_entities.append(target_soc_number)
         number_entities.append(
-            SAICMGTargetSOCNumber(coordinator, client, vin_info, vin)
+            SAICMGChargeLimit(coordinator, client, vin_info, vin, target_soc_number)
         )
 
     async_add_entities(number_entities)
@@ -59,7 +62,7 @@ class SAICMGTargetSOCNumber(CoordinatorEntity, NumberEntity):
         }
 
     @property
-    def native_value(self):
+    def native_value(self) -> int | None:
         """Return the current target SOC value."""
         charging_data = self.coordinator.data.get("charging")
         if charging_data:
@@ -84,7 +87,7 @@ class SAICMGTargetSOCNumber(CoordinatorEntity, NumberEntity):
         return self._last_valid_value
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon based on the current SOC value."""
         if self.native_value is not None:
             if self.native_value >= 100:
@@ -108,7 +111,7 @@ class SAICMGTargetSOCNumber(CoordinatorEntity, NumberEntity):
             return "mdi:battery-charging-outline"
 
     @property
-    def available(self):
+    def available(self) -> bool:
         """Return True if the number entity is available."""
         return (
             self.coordinator.last_update_success
@@ -125,3 +128,99 @@ class SAICMGTargetSOCNumber(CoordinatorEntity, NumberEntity):
             await self.coordinator.async_request_refresh()
         except Exception as e:
             LOGGER.error("Error setting Target SOC for VIN %s: %s", self._vin, e)
+
+
+class SAICMGChargeLimit(CoordinatorEntity, NumberEntity):
+    """Representation of a bmsAltngChrgCrntDspCmd number entity."""
+
+    valid_values = [6, 8, 16, 99]
+
+    def __init__(self, coordinator, client, vin_info, vin, target_soc_number):
+        """Initialize the bmsAltngChrgCrntDspCmd number entity."""
+        super().__init__(coordinator)
+        self._target_soc_number = target_soc_number
+        self._client = client
+        self._vin = vin
+        self._vin_info = vin_info
+        self._last_valid_value = None
+
+        self._attr_name = f"{vin_info.brandName} {vin_info.modelName} Charge limit"
+        self._attr_unique_id = f"{vin}_charge_limit"
+        self._attr_native_min_value = 6
+        self._attr_native_max_value = 99
+        self._attr_native_step = 1
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_mode = NumberMode.SLIDER
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._vin)},
+            "name": f"{self._vin_info.brandName} {self._vin_info.modelName}",
+            "manufacturer": self._vin_info.brandName,
+            "model": self._vin_info.modelName,
+            "serial_number": self._vin,
+        }
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the current bmsAltngChrgCrntDspCmd value."""
+        charging_data = self.coordinator.data.get("charging")
+        if charging_data:
+            chrg_mgmt_data = getattr(charging_data, "chrgMgmtData", None)
+            if chrg_mgmt_data:
+                bac_cmd = getattr(chrg_mgmt_data, "bmsAltngChrgCrntDspCmd", None)
+                # Map the SOC command to percentage
+                bac_mapping = {
+                    ChargeCurrentLimitCode.C_6A.value: 6,
+                    ChargeCurrentLimitCode.C_8A.value: 8,
+                    ChargeCurrentLimitCode.C_16A.value: 16,
+                    ChargeCurrentLimitCode.C_MAX.value: 99,
+                }
+                bac_value = bac_mapping.get(bac_cmd)
+                if bac_value is not None:
+                    self._last_valid_value = bac_value
+                    return bac_value
+        # Return the last valid value if current data is invalid
+        return self._last_valid_value
+
+    @property
+    def icon(self) -> str:
+        """Return the icon based on the current bmsAltngChrgCrntDspCmd value."""
+        if self.native_value is not None:
+            if self.native_value > ChargeCurrentLimitCode.C_16A.value:
+                return "mdi:battery-charging-high"
+            elif self.native_value == ChargeCurrentLimitCode.C_16A.value:
+                return "mdi:battery-charging-medium"
+            elif self.native_value <= ChargeCurrentLimitCode.C_16A.value:
+                return "mdi:battery-charging-low"
+            else:
+                return "mdi:battery-charging-outline"
+        else:
+            # Return a default icon when native_value is None
+            return "mdi:battery-charging-outline"
+
+    @property
+    def available(self) -> bool:
+        """Return True if the number entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("charging") is not None
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the charge limit to the specified value."""
+        charge_limit = self.valid_values[-1]
+        for valid_value in self.valid_values:
+            if value <= valid_value:
+                charge_limit = valid_value
+                break
+        try:
+            await self._client.set_charge_limit(
+                self._vin, charge_limit, self._target_soc_number.native_value
+            )
+            # Schedule data refresh
+            await self.coordinator.async_request_refresh()
+        except Exception as e:
+            LOGGER.error("Error setting charge limit for VIN %s: %s", self._vin, e)

--- a/custom_components/mg_saic/services.py
+++ b/custom_components/mg_saic/services.py
@@ -16,6 +16,7 @@ SERVICE_START_AC = "start_ac"
 SERVICE_STOP_AC = "stop_ac"
 SERVICE_OPEN_TAILGATE = "open_tailgate"
 SERVICE_SET_TARGET_SOC = "set_target_soc"
+SERVICE_SET_CHARGE_LIMIT = "set_charge_limit"
 SERVICE_START_AC_WITH_SETTINGS = "start_ac_with_settings"
 SERVICE_START_BATTERY_HEATING = "start_battery_heating"
 SERVICE_START_CHARGING = "start_charging"
@@ -208,6 +209,16 @@ async def async_setup_services(hass: HomeAssistant, client: SAICMGAPIClient) -> 
             await client.set_target_soc(vin, target_soc)
         except Exception as e:
             LOGGER.error("Error setting target SOC for VIN %s: %s", vin, e)
+
+    async def handle_set_charge_limit(call: ServiceCall) -> None:
+        """Handle the set_charge_limit service call."""
+        vin = call.data["vin"]
+        target_soc = call.data["target_soc"]
+        charge_limit = call.data["charge_limit"]
+        try:
+            await client.set_charge_limit(vin, charge_limit, target_soc)
+        except Exception as e:
+            LOGGER.error("Error setting charge limit for VIN %s: %s", vin, e)
 
     async def handle_control_rear_window_heat(call: ServiceCall) -> None:
         """Handle the control_rear_window_heat service call."""


### PR DESCRIPTION
When setting target SOC, the underlying API allows the charge limit to also be specified. Create a number which allows this to be managed.

The current implementation is a bit messy, and is not ready to merge. While this works correctly when modifying the charge limit (that is, it respects the current target SOC), the reverse it not true; when the target SOC is modified, the charge limit is lost.