### PR TITLE
Bump saic-ismart-client-ng version (closes #104)

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/ad-ha/mg-saic-ha",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ad-ha/mg-saic-ha/issues",
-  "requirements": ["requests", "pycryptodome", "saic-ismart-client-ng==0.6.0"],
-  "version": "0.9.2"
+  "requirements": ["requests", "pycryptodome", "saic-ismart-client-ng==0.7.1"],
+  "version": "0.9.3"
 }


### PR DESCRIPTION
Bump saic-ismart-client-ng version to 0.7.1, correcting issues with httpx (closes #104)