### PR TITLE
Fix HVACMode.HEAT for MG4 Electric PTC resistive heater

### DIFF
--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -61,6 +61,7 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         )
         self._attr_hvac_modes = [
             HVACMode.OFF,
+            HVACMode.HEAT,
             HVACMode.COOL,
             HVACMode.FAN_ONLY,
         ]
@@ -123,7 +124,9 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         if climate_status == 3:
             return HVACMode.COOL
         elif climate_status == 2:
-            return HVACMode.FAN_ONLY
+            return HVACMode.HEAT
+        elif climate_status == 4:
+            return HVACMode.FAN_ONLY  # unconfirmed — assumed by elimination
 
         return HVACMode.OFF
 
@@ -145,8 +148,25 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
             # Get temperature index from coordinator
             temperature_idx = self.coordinator.get_ac_temperature_idx(temp_clamped)
 
-            if hvac_mode == HVACMode.COOL:
-                # Cooling mode
+            if hvac_mode == HVACMode.HEAT:
+                # Heat mode: confirmed from iSMART app traffic capture.
+                # The MG4 heats via PTC resistive heater, not the compressor.
+                #   AC_ON_OFF = 0x00 (explicit zero — absent is NOT the same)
+                #   TEMPERATURE = max index (19 = 33°C for EH32)
+                # AC_ON_OFF=0x01 always drives the compressor in cooling mode.
+                # AC_ON_OFF absent leaves the car in its previous state.
+                heat_temperature_idx = self.coordinator.get_ac_temperature_idx(
+                    int(self.max_temp)
+                )
+                await self._client.start_climate(
+                    self._vin,
+                    temperature_idx=heat_temperature_idx,
+                    fan_speed=2,  # AUTO fan required for PTC heater — confirmed from iSMART traffic
+                    ac_on=False,
+                )
+
+            elif hvac_mode == HVACMode.COOL:
+                # Explicit cooling mode
                 await self._client.start_climate(
                     self._vin,
                     temperature_idx=temperature_idx,
@@ -185,7 +205,7 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         immediate_interval = self.coordinator.after_action_delay
         long_interval = self.coordinator.ac_long_interval
 
-        await self.async_set_hvac_mode(HVACMode.COOL)
+        await self.async_set_hvac_mode(HVACMode.HEAT)
         await self.coordinator.schedule_action_refresh(
             self._vin,
             immediate_interval,


### PR DESCRIPTION
## Problem

Triggering `hvac_mode: heat` on the MG4 Electric caused the car to **cool** the cabin instead of heat it, even at 4°C interior temperature. The integration had no `HVACMode.HEAT` implementation — `async_turn_on()` defaulted to `HVACMode.COOL`.

## Root Cause

Identified by decrypting real iSMART app traffic (AES-CBC, captured via mitmproxy):

The MG4 Electric heats via a **PTC resistive heater**, not a heat pump compressor. The RVC protocol parameters for heating vs cooling:

| Mode | FAN_SPEED (paramId 19) | TEMPERATURE (paramId 20) | AC_ON_OFF (paramId 22) |
|------|------------------------|--------------------------|------------------------|
| HEAT | **2 (AUTO)** | max index (19 = 33°C for EH32) | **0x00** |
| COOL | any | target temp index | 0x01 |
| OFF  | 0 | — | 0x00 |

Critical findings confirmed from iSMART traffic capture:
- `AC_ON_OFF=0x01` → compressor ON → always cools
- `AC_ON_OFF=0x00` → compressor OFF → PTC heater engages **only when `FAN_SPEED=2` (AUTO)**
- `AC_ON_OFF` absent → car stays in previous state (NOT the same as 0x00)
- `FAN_SPEED=2` (AUTO) is **mandatory** for PTC heating — any other value (1/3/5) with `AC_ON_OFF=0x00` does not engage the heater

## Changes — `climate.py`

### 1. Added `HVACMode.HEAT` to supported modes
```python
self._attr_hvac_modes = [
    HVACMode.OFF,
    HVACMode.HEAT,   # ← added
    HVACMode.COOL,
    HVACMode.FAN_ONLY,
]
```

### 2. Fixed `hvac_mode` property — `remoteClimateStatus` mapping
Confirmed from live telemetry while PTC heating was active:
```python
if climate_status == 3:
    return HVACMode.COOL
elif climate_status == 2:       # ← was FAN_ONLY, confirmed HEAT from live data
    return HVACMode.HEAT
elif climate_status == 4:
    return HVACMode.FAN_ONLY    # unconfirmed — assumed by elimination
```

| remoteClimateStatus | Mode |
|---|---|
| 0 | OFF |
| 2 | HEAT (PTC heater active) ✓ confirmed from live telemetry |
| 3 | COOL (compressor active) ✓ confirmed from live telemetry |
| 4 | FAN_ONLY ⚠ unconfirmed — assumed by elimination |

### 3. Implemented `HVACMode.HEAT` in `async_set_hvac_mode`
```python
if hvac_mode == HVACMode.HEAT:
    heat_temperature_idx = self.coordinator.get_ac_temperature_idx(
        int(self.max_temp)
    )
    await self._client.start_climate(
        self._vin,
        temperature_idx=heat_temperature_idx,
        fan_speed=2,  # AUTO fan required for PTC heater — confirmed from iSMART traffic
        ac_on=False,
    )
```

### 4. `async_turn_on()` defaults to `HVACMode.HEAT`
```python
async def async_turn_on(self):
    await self.async_set_hvac_mode(HVACMode.HEAT)
```

## Testing

Tested on MG4 Electric 2024 (series EH32MCE L, Europe region):
- `hvac_mode: heat` → iSMART app shows HIGH button highlighted ✓
- Interior temperature rose from 22°C → 25°C over one poll interval ✓
- `remoteClimateStatus=2` confirmed in telemetry during heating ✓
- `hvac_mode: cool` unchanged and still working ✓
- `hvac_mode: off` unchanged and still working ✓