### PR TITLE
Fix service lifecycle and action refresh handling

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,0 +1,16 @@
+name: Python unit tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -p "test_*.py"

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -11,6 +11,9 @@ from .services import async_setup_services, async_unload_services
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up MG SAIC from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN].setdefault("clients_by_vin", {})
+    hass.data[DOMAIN].setdefault("coordinators_by_vin", {})
+    hass.data[DOMAIN].setdefault("services_registered", False)
 
     username = entry.data["username"]
     password = entry.data["password"]
@@ -48,8 +51,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         hass.data[DOMAIN][f"{entry.entry_id}_coordinator"] = coordinator
 
-        # Store coordinator by VIN for data refresh after service calls
-        hass.data[DOMAIN].setdefault("coordinators_by_vin", {})
+        # Store resources by VIN so global services can resolve the correct entry.
+        hass.data[DOMAIN]["clients_by_vin"][vin] = client
         hass.data[DOMAIN]["coordinators_by_vin"][vin] = coordinator
 
         # Register an update listener to handle options updates
@@ -57,8 +60,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-        # Register Services
-        await async_setup_services(hass, client, coordinator)
+        # Register services only once; each service resolves the target VIN at runtime.
+        if not hass.data[DOMAIN]["services_registered"]:
+            await async_setup_services(hass)
+            hass.data[DOMAIN]["services_registered"] = True
 
         LOGGER.info("MG SAIC integration setup completed successfully.")
         return True
@@ -77,10 +82,30 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        domain_data = hass.data[DOMAIN]
+        vin = entry.data.get("vin")
 
-        # If there are no more entries, unload services
-        if not hass.data[DOMAIN]:
+        coordinator = domain_data.pop(f"{entry.entry_id}_coordinator", None)
+        client = domain_data.pop(entry.entry_id, None)
+
+        if vin:
+            domain_data.get("clients_by_vin", {}).pop(vin, None)
+            domain_data.get("coordinators_by_vin", {}).pop(vin, None)
+
+        if coordinator is not None:
+            await coordinator.async_shutdown()
+
+        if client is not None:
+            await client.close()
+
+        # If there are no more entries, unload services and clean the domain data.
+        if not domain_data.get("clients_by_vin"):
             await async_unload_services(hass)
+            domain_data.pop("clients_by_vin", None)
+            domain_data.pop("coordinators_by_vin", None)
+            domain_data.pop("services_registered", None)
+
+        if not domain_data:
+            hass.data.pop(DOMAIN, None)
 
     return unload_ok

--- a/custom_components/mg_saic/api.py
+++ b/custom_components/mg_saic/api.py
@@ -8,6 +8,7 @@ from saic_ismart_client_ng.api.vehicle_charging import (
     ChargeCurrentLimitCode as ExternalChargeCurrentLimitCode,
 )
 from .const import LOGGER, REGION_BASE_URIS, BatterySoc, ChargeCurrentLimitOption
+from .logic import normalize_sunroof_action
 
 
 class SAICMGAPIClient:
@@ -410,6 +411,7 @@ class SAICMGAPIClient:
             LOGGER.info("Vehicle locked successfully.")
         except Exception as e:
             LOGGER.error("Error locking vehicle: %s", e)
+            raise
 
     async def open_tailgate(self, vin):
         """Open the vehicle tailgate."""
@@ -418,6 +420,7 @@ class SAICMGAPIClient:
             LOGGER.info("Tailgate opened successfully.")
         except Exception as e:
             LOGGER.error("Error opening tailgate: %s", e)
+            raise
 
     async def unlock_vehicle(self, vin):
         """Unlock the vehicle."""
@@ -426,17 +429,22 @@ class SAICMGAPIClient:
             LOGGER.info("Vehicle unlocked successfully.")
         except Exception as e:
             LOGGER.error("Error unlocking vehicle: %s", e)
+            raise
 
     # WINDOWS CONTROL
     async def control_sunroof(self, vin, action):
         """Control the sunroof (open/close)."""
         try:
             LOGGER.debug(f"Sunroof control - VIN: {vin}, action: {action}")
-            should_open = action == "open"
+            should_open, action_name = normalize_sunroof_action(action)
             await self._make_api_call(
                 self.saic_api.control_sunroof, vin=vin, should_open=should_open
             )
-            LOGGER.info(f"Sunroof {action} command sent successfully for VIN: {vin}")
+            LOGGER.info(
+                "Sunroof %s command sent successfully for VIN: %s",
+                action_name,
+                vin,
+            )
         except Exception as e:
             LOGGER.error("Error controlling sunroof for VIN %s: %s", vin, e)
             raise
@@ -444,6 +452,9 @@ class SAICMGAPIClient:
     # SESSION MANAGEMENT
     async def close(self):
         """Close the client session."""
+        if self.saic_api is None:
+            return
+
         try:
             await self.saic_api.close()
             LOGGER.info("Closed MG SAIC API session.")

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -2,10 +2,12 @@
 
 from datetime import datetime, timedelta, timezone
 import asyncio
+from contextlib import suppress
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import utcnow
 from .api import SAICMGAPIClient
+from .logic import select_update_interval
 from .const import (
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CHARGING_STATUS_CODES,
@@ -67,6 +69,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Next Update Time
         self.next_update_time = None
+        self._action_refresh_task = None
+        self._action_refresh_generation = 0
 
         # Initialize with default values
         self.vehicle_series = None
@@ -91,7 +95,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
         # Base update intervals
-        self.update_interval = get_interval("update_interval", UPDATE_INTERVAL)
+        self.default_update_interval = get_interval("update_interval", UPDATE_INTERVAL)
+        self.update_interval = self.default_update_interval
         self.charging_update_interval = get_interval(
             "charging_update_interval", UPDATE_INTERVAL_CHARGING
         )
@@ -155,7 +160,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         LOGGER.debug(
             f"Update intervals initialized: "
-            f"Default: {self.update_interval}, "
+            f"Default: {self.default_update_interval}, "
             f"Charging: {self.charging_update_interval}, "
             f"Powered: {self.powered_update_interval}, "
             f"After Shutdown: {self.after_shutdown_update_interval}, "
@@ -197,7 +202,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
         # Update all update intervals
-        self.update_interval = get_interval("update_interval", UPDATE_INTERVAL)
+        self.default_update_interval = get_interval("update_interval", UPDATE_INTERVAL)
+        self.update_interval = self.default_update_interval
         self.charging_update_interval = get_interval(
             "charging_update_interval", UPDATE_INTERVAL_CHARGING
         )
@@ -266,7 +272,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         LOGGER.debug(
             f"Update intervals updated via options: "
-            f"Default: {self.update_interval}, "
+            f"Default: {self.default_update_interval}, "
             f"Charging: {self.charging_update_interval}, "
             f"Powered: {self.powered_update_interval}, "
             f"After Shutdown: {self.after_shutdown_update_interval}, "
@@ -287,24 +293,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             f"Charging Current: {self.charging_current_long_interval}"
         )
 
-        # Reschedule the refresh with the new update interval
-        if not self.is_charging and not self.is_powered_on:
-            new_interval = self.update_interval
-            if self.update_interval != new_interval:
-                LOGGER.debug(
-                    f"Update interval reset to default: {self.update_interval}"
-                )
-                if self._unsub_refresh:
-                    self._unsub_refresh()
-                self._schedule_refresh()
-
-        # Reschedule the refresh immediately with the new update interval
-        if self._unsub_refresh:
-            self._unsub_refresh()
-
-        # Force recalculation of the next update time based on the new interval
-        self.next_update_time = utcnow() + self.update_interval
-        self._schedule_refresh()
+        if not getattr(self, "_action_interval_active", False):
+            self._adjust_update_interval()
+        else:
+            self.next_update_time = utcnow() + self.update_interval
+            self.async_update_listeners()
 
     async def async_setup(self):
         """Set up the coordinator."""
@@ -657,23 +650,27 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
         # Determine update interval based on state and recent activity
-        if self.is_powered_on:
-            self.update_interval = self.powered_update_interval
+        self.update_interval = select_update_interval(
+            is_powered_on=self.is_powered_on,
+            is_charging=self.is_charging,
+            idle_duration=idle_duration,
+            activity_duration=activity_duration,
+            default_update_interval=self.default_update_interval,
+            powered_update_interval=self.powered_update_interval,
+            charging_update_interval=self.charging_update_interval,
+            grace_period_update_interval=self.grace_period_update_interval,
+            after_shutdown_update_interval=self.after_shutdown_update_interval,
+        )
+
+        if self.update_interval == self.powered_update_interval:
             LOGGER.debug("Vehicle is powered on. Using powered update interval.")
-        elif self.is_charging:
-            self.update_interval = self.charging_update_interval
+        elif self.update_interval == self.charging_update_interval:
             LOGGER.debug("Vehicle is charging. Using charging update interval.")
-        elif (
-            activity_duration <= self.grace_period_update_interval
-            or idle_duration <= self.grace_period_update_interval
-        ):
-            self.update_interval = self.grace_period_update_interval
+        elif self.update_interval == self.grace_period_update_interval:
             LOGGER.debug("Within grace period. Using grace period interval.")
-        elif idle_duration <= self.after_shutdown_update_interval:
-            self.update_interval = self.after_shutdown_update_interval
+        elif self.update_interval == self.after_shutdown_update_interval:
             LOGGER.debug("Within shutdown window. Using shutdown interval.")
         else:
-            self.update_interval = UPDATE_INTERVAL  # Use the default update interval
             LOGGER.debug("No recent activity. Using default update interval.")
 
         # Log and schedule the next refresh
@@ -682,12 +679,33 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
     # Additional Update Intervals for Actions and Confirmation
     async def schedule_action_refresh(self, vin, immediate_interval, long_interval):
-        """Schedule immediate and long-interval updates after an action."""
-        # Prevent state-driven adjustments during action sequence
+        """Schedule non-blocking follow-up refreshes after an action."""
+        self._action_refresh_generation += 1
+        generation = self._action_refresh_generation
+
+        if self._action_refresh_task and not self._action_refresh_task.done():
+            self._action_refresh_task.cancel()
+
+        self._action_refresh_task = self.hass.async_create_task(
+            self._run_action_refresh_sequence(
+                vin,
+                immediate_interval,
+                long_interval,
+                generation,
+            )
+        )
+
+    async def _run_action_refresh_sequence(
+        self,
+        vin,
+        immediate_interval,
+        long_interval,
+        generation,
+    ):
+        """Run action follow-up refreshes in the background."""
         self._action_interval_active = True
 
         try:
-            # Apply the immediate interval
             self.update_interval = immediate_interval
             self.next_update_time = utcnow() + self.update_interval
             self.async_update_listeners()
@@ -698,10 +716,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             )
             await self.async_request_refresh()
 
-            # Wait for the immediate interval
             await asyncio.sleep(immediate_interval.total_seconds())
 
-            # Apply the long interval
             self.update_interval = long_interval
             self.next_update_time = utcnow() + self.update_interval
             self.async_update_listeners()
@@ -712,13 +728,29 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             )
             await self.async_request_refresh()
 
-            # Wait for the long interval
             await asyncio.sleep(long_interval.total_seconds())
-
+        except asyncio.CancelledError:
+            LOGGER.debug("Cancelled action refresh sequence for VIN: %s.", vin)
+            raise
         finally:
-            # Allow state-based adjustments again
-            self._action_interval_active = False
-            self._adjust_update_interval()
+            if generation == self._action_refresh_generation:
+                self._action_interval_active = False
+                self._action_refresh_task = None
+                self._adjust_update_interval()
+
+    async def async_shutdown(self):
+        """Release coordinator resources when the entry is unloaded."""
+        self._action_refresh_generation += 1
+
+        if self._action_refresh_task and not self._action_refresh_task.done():
+            self._action_refresh_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._action_refresh_task
+        self._action_refresh_task = None
+
+        if self._unsub_refresh:
+            self._unsub_refresh()
+            self._unsub_refresh = None
 
     def _schedule_refresh(self):
         """Schedule the next refresh and update listeners."""

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -1,0 +1,55 @@
+"""Pure logic helpers used by the integration.
+
+These helpers deliberately avoid Home Assistant imports so they can be tested
+with the standard library only.
+"""
+
+from datetime import timedelta
+
+
+def normalize_sunroof_action(action):
+    """Normalize a sunroof action to `(should_open, action_name)`."""
+    if isinstance(action, bool):
+        return action, "open" if action else "close"
+
+    action_name = str(action).lower()
+    if action_name not in {"open", "close"}:
+        raise ValueError(
+            f"Invalid sunroof action '{action}'. Expected 'open' or 'close'."
+        )
+
+    return action_name == "open", action_name
+
+
+def select_update_interval(
+    *,
+    is_powered_on,
+    is_charging,
+    idle_duration,
+    activity_duration,
+    default_update_interval,
+    powered_update_interval,
+    charging_update_interval,
+    grace_period_update_interval,
+    after_shutdown_update_interval,
+):
+    """Return the interval that should be used for the current state."""
+    if is_powered_on:
+        return powered_update_interval
+
+    if is_charging:
+        return charging_update_interval
+
+    if (
+        activity_duration <= grace_period_update_interval
+        or idle_duration <= grace_period_update_interval
+    ):
+        return grace_period_update_interval
+
+    if idle_duration <= after_shutdown_update_interval:
+        return after_shutdown_update_interval
+
+    if not isinstance(default_update_interval, timedelta):
+        raise TypeError("default_update_interval must be a timedelta")
+
+    return default_update_interval

--- a/custom_components/mg_saic/services.py
+++ b/custom_components/mg_saic/services.py
@@ -3,19 +3,12 @@
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
-import asyncio
 
-from .api import SAICMGAPIClient
-from .coordinator import SAICMGDataUpdateCoordinator
 from .const import (
     DOMAIN,
     LOGGER,
     ChargeCurrentLimitOption,
     BatterySoc,
-)
-from saic_ismart_client_ng.api.vehicle_charging import (
-    TargetBatteryCode,
-    ChargeCurrentLimitCode as ExternalChargeCurrentLimitCode,
 )
 
 SERVICE_CONTROL_CHARGING_PORT_LOCK = "control_charging_port_lock"
@@ -49,8 +42,8 @@ SERVICE_ACTION_SCHEMA = vol.Schema(
 SERVICE_CONTROL_HEATED_SEAT_SCHEMA = vol.Schema(
     {
         vol.Required("vin"): cv.string,
-        vol.Required("seat"): vol.In(["front_left", "front_right"]),
-        vol.Required("level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
+        vol.Required("left_level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
+        vol.Required("right_level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
     }
 )
 
@@ -103,11 +96,19 @@ SERVICE_SUNROOF_SCHEMA = vol.Schema(
 SERVICE_VIN_SCHEMA = vol.Schema({vol.Required("vin"): cv.string})
 
 
-async def async_setup_services(
-    hass: HomeAssistant,
-    client: SAICMGAPIClient,
-    coordinator: SAICMGDataUpdateCoordinator,
-) -> None:
+def _get_vehicle_resources(hass: HomeAssistant, vin: str):
+    """Resolve the client and coordinator for a VIN."""
+    domain_data = hass.data.get(DOMAIN, {})
+    client = domain_data.get("clients_by_vin", {}).get(vin)
+    coordinator = domain_data.get("coordinators_by_vin", {}).get(vin)
+
+    if client is None or coordinator is None:
+        raise ValueError(f"No integration resources found for VIN {vin}")
+
+    return client, coordinator
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services for the MG SAIC integration."""
 
     # Dynamically define SERVICE_START_CLIMATE_SCHEMA based on vehicle's temperature limits
@@ -125,8 +126,9 @@ async def async_setup_services(
         """Handle the lock_vehicle service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.ac_long_interval
+            long_interval = coordinator.lock_unlock_long_interval
 
             await client.lock_vehicle(vin)
             LOGGER.info("Vehicle locked successfully for VIN: %s", vin)
@@ -142,8 +144,17 @@ async def async_setup_services(
         """Handle the unlock_vehicle service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.lock_unlock_long_interval
+
             await client.unlock_vehicle(vin)
             LOGGER.info("Vehicle unlocked successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
         except Exception as e:
             LOGGER.error("Error unlocking vehicle for VIN %s: %s", vin, e)
 
@@ -151,6 +162,7 @@ async def async_setup_services(
         """Handle the start_ac service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.ac_long_interval
 
@@ -191,6 +203,7 @@ async def async_setup_services(
         """Handle the stop_ac service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.ac_long_interval
 
@@ -211,6 +224,7 @@ async def async_setup_services(
         fan_speed = call.data["fan_speed"]
         ac_on = call.data["ac_on"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             min_temp = coordinator.min_temp
             max_temp = coordinator.max_temp
 
@@ -252,6 +266,7 @@ async def async_setup_services(
         """Handle the open_tailgate service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.tailgate_long_interval
 
@@ -269,6 +284,7 @@ async def async_setup_services(
         """Handle the trigger_alarm service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.alarm_long_interval
             await client.trigger_alarm(vin)
@@ -285,6 +301,7 @@ async def async_setup_services(
         """Handle the start_charging service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.charging_long_interval
 
@@ -303,6 +320,7 @@ async def async_setup_services(
         """Handle the stop_charging service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.charging_long_interval
 
@@ -321,6 +339,7 @@ async def async_setup_services(
         """Handle the start_battery_heating service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.battery_heating_long_interval
 
@@ -339,6 +358,7 @@ async def async_setup_services(
         """Handle the stop_battery_heating service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.battery_heating_long_interval
 
@@ -358,6 +378,7 @@ async def async_setup_services(
         vin = call.data["vin"]
         current_limit = call.data["current_limit"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.charging_current_long_interval
 
@@ -421,6 +442,7 @@ async def async_setup_services(
         vin = call.data["vin"]
         target_soc = call.data["target_soc"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.target_soc_long_interval
 
@@ -439,6 +461,7 @@ async def async_setup_services(
         vin = call.data["vin"]
         action = call.data["action"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.rear_window_heat_long_interval
 
@@ -455,9 +478,10 @@ async def async_setup_services(
     async def handle_control_heated_seats(call: ServiceCall) -> None:
         """Handle the control_heated_seats service call."""
         vin = call.data["vin"]
-        left_level = call.data.get("left_level", 0)
-        right_level = call.data.get("right_level", 0)
+        left_level = call.data["left_level"]
+        right_level = call.data["right_level"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.heated_seats_long_interval
 
@@ -480,6 +504,7 @@ async def async_setup_services(
         """Handle the start_front_defrost service call."""
         vin = call.data["vin"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.front_defrost_long_interval
 
@@ -496,18 +521,18 @@ async def async_setup_services(
     async def handle_update_vehicle_data(call: ServiceCall) -> None:
         """Handle the update_vehicle_data service call."""
         vin = call.data["vin"]
-        coordinators_by_vin = hass.data[DOMAIN].get("coordinators_by_vin", {})
-        coordinator = coordinators_by_vin.get(vin)
-        if coordinator:
+        try:
+            _, coordinator = _get_vehicle_resources(hass, vin)
             await coordinator.async_request_refresh()
             LOGGER.info("Data update triggered for VIN: %s", vin)
-        else:
-            LOGGER.warning("Coordinator not found for VIN %s", vin)
+        except Exception as e:
+            LOGGER.warning("Coordinator not found for VIN %s: %s", vin, e)
 
     async def handle_control_sunroof(call: ServiceCall) -> None:
         vin = call.data["vin"]
         should_open = call.data["should_open"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.sunroof_long_interval
 
@@ -525,6 +550,7 @@ async def async_setup_services(
         vin = call.data["vin"]
         unlock = call.data["unlock"]
         try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
             immediate_interval = coordinator.after_action_delay
             long_interval = coordinator.charging_port_lock_long_interval
 

--- a/custom_components/mg_saic/switch.py
+++ b/custom_components/mg_saic/switch.py
@@ -24,12 +24,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     switches = []
 
-    # Extract vehicle configuration
-    vehicle_config = {
-        config.itemCode: config.itemValue
-        for config in vin_info.vehicleModelConfiguration
-    }
-
     # Front Defrost Switch
     switches.append(SAICMGFrontDefrostSwitch(coordinator, client, entry, vin_info, vin))
 
@@ -56,7 +50,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     vin_info,
                     vin,
                     "Front Left",
-                    "front_left",
+                    "left",
+                    "frontLeftSeatHeatLevel",
                 ),
                 SAICMGHeatedSeatsSwitch(
                     coordinator,
@@ -65,7 +60,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     vin_info,
                     vin,
                     "Front Right",
-                    "front_right",
+                    "right",
+                    "frontRightSeatHeatLevel",
                 ),
             ]
         )
@@ -381,7 +377,17 @@ class SAICMGFrontDefrostSwitch(CoordinatorEntity, SwitchEntity):
 class SAICMGHeatedSeatsSwitch(SAICMGVehicleSwitch):
     """Switch to control individual heated seats."""
 
-    def __init__(self, coordinator, client, entry, vin_info, vin, seat_name, seat_side):
+    def __init__(
+        self,
+        coordinator,
+        client,
+        entry,
+        vin_info,
+        vin,
+        seat_name,
+        seat_side,
+        status_attr,
+    ):
         """Initialize the Heated Seat switch."""
         super().__init__(
             coordinator,
@@ -393,6 +399,7 @@ class SAICMGHeatedSeatsSwitch(SAICMGVehicleSwitch):
             "mdi:car-seat-heater",
         )
         self._seat_side = seat_side
+        self._status_attr = status_attr
         self._attr_name = (
             f"{vin_info.brandName} {vin_info.modelName} Heated Seat {seat_name}"
         )
@@ -414,7 +421,7 @@ class SAICMGHeatedSeatsSwitch(SAICMGVehicleSwitch):
             if basic_status:
                 seat_level = getattr(
                     basic_status,
-                    f"{self._seat_side}SeatHeatLevel",
+                    self._status_attr,
                     0,
                 )
                 return seat_level > 0

--- a/docs/review-fixes-2026-03-21.md
+++ b/docs/review-fixes-2026-03-21.md
@@ -1,0 +1,151 @@
+# Review Fixes - 2026-03-21
+
+This note documents the fixes applied after the repository review and explains
+why each change was made.
+
+## 1. Non-blocking action refresh scheduling
+
+Files:
+- `custom_components/mg_saic/coordinator.py`
+
+What changed:
+- Replaced the blocking `schedule_action_refresh()` implementation with a
+  background task.
+- Added task cancellation and coordinator shutdown cleanup.
+
+Why:
+- The previous implementation awaited multiple `sleep()` calls directly inside
+  service/entity actions. A lock, climate or charging command could therefore
+  remain pending for minutes before returning control to Home Assistant.
+- The new version schedules the follow-up refresh sequence in the background,
+  keeps only one active action-refresh sequence per coordinator and cancels it
+  safely when the entry is unloaded.
+
+## 2. Correct multi-VIN service routing
+
+Files:
+- `custom_components/mg_saic/__init__.py`
+- `custom_components/mg_saic/services.py`
+
+What changed:
+- Added `clients_by_vin` alongside `coordinators_by_vin`.
+- Registered services only once for the integration domain.
+- Updated every service handler to resolve the correct client/coordinator from
+  the VIN provided in the service call.
+
+Why:
+- Services were previously registered once per config entry and closed over the
+  client/coordinator of that entry. With multiple vehicles, the global service
+  handlers could operate on the wrong coordinator and refresh the wrong VIN.
+- Resolving resources by VIN at call time makes service behavior deterministic.
+
+## 3. Proper unload and resource cleanup
+
+Files:
+- `custom_components/mg_saic/__init__.py`
+- `custom_components/mg_saic/coordinator.py`
+- `custom_components/mg_saic/api.py`
+
+What changed:
+- Removed entry-specific client and coordinator objects on unload.
+- Removed VIN indexes on unload.
+- Added coordinator shutdown logic to cancel background tasks and scheduled
+  refresh callbacks.
+- Closed the API client cleanly and made `close()` tolerate an uninitialized
+  session.
+
+Why:
+- The previous unload path left stale coordinators behind and could keep the
+  service registry alive even when the integration had no remaining entries.
+- Cleaning the coordinator tasks and API client prevents leaked callbacks and
+  stale references.
+
+## 4. Heated seats service and switch fixes
+
+Files:
+- `custom_components/mg_saic/services.py`
+- `custom_components/mg_saic/services.yaml`
+- `custom_components/mg_saic/switch.py`
+
+What changed:
+- Aligned the service schema with the documented `left_level` and
+  `right_level` fields.
+- Fixed the heated seat switch constructor to use stable seat identifiers.
+- Mapped each heated seat switch to the correct status attribute from the
+  vehicle payload.
+
+Why:
+- The service schema and service handler disagreed about the accepted payload.
+- The seat switches used inconsistent identifiers and therefore never reached
+  the branch that sends the command, while also reading the wrong status field.
+
+## 5. Sunroof service compatibility
+
+Files:
+- `custom_components/mg_saic/api.py`
+- `custom_components/mg_saic/services.py`
+
+What changed:
+- Made `control_sunroof()` accept either a boolean or an `"open"/"close"`
+  string and normalize both forms internally.
+
+Why:
+- The service layer passed a boolean while the API wrapper expected a string,
+  which could invert behavior and always resolve to closing the sunroof.
+
+## 6. Preserve the configured default polling interval
+
+Files:
+- `custom_components/mg_saic/coordinator.py`
+
+What changed:
+- Added a dedicated `default_update_interval`.
+- Reused that value whenever the vehicle returns to the idle/default polling
+  state.
+
+Why:
+- The previous logic fell back to the constant `UPDATE_INTERVAL`, which meant a
+  user-defined polling interval was silently lost after state transitions.
+
+## 7. API errors now propagate to callers
+
+Files:
+- `custom_components/mg_saic/api.py`
+
+What changed:
+- Re-raised exceptions in `lock_vehicle()`, `unlock_vehicle()` and
+  `open_tailgate()`.
+
+Why:
+- The service/entity layers were able to log success after a failed API call
+  because those methods swallowed the exception after logging it once.
+
+## Validation performed
+
+- `python3 -m compileall custom_components/mg_saic`
+- `python3 -m unittest discover -s tests -p "test_*.py"`
+
+## 8. Lightweight automated tests
+
+Files:
+- `custom_components/mg_saic/logic.py`
+- `tests/test_logic.py`
+- `.github/workflows/python-tests.yaml`
+
+What changed:
+- Extracted pure helper logic for sunroof normalization and update interval
+  selection.
+- Added standard-library unit tests for these rules.
+- Added a CI workflow to run the tests on pushes and pull requests.
+
+Why:
+- The repository only had HACS and Hassfest validation. These new tests cover
+  two regression-prone code paths without requiring a full Home Assistant test
+  harness.
+
+## Remaining gap
+
+- The repository still does not include end-to-end Home Assistant tests for the
+  config flow, entity lifecycle and service registration. The most critical
+  pure logic now has automated coverage, but runtime HA integration coverage is
+  still a future improvement.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,101 @@
+"""Unit tests for pure integration logic."""
+
+from datetime import timedelta
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "mg_saic"
+    / "logic.py"
+)
+SPEC = importlib.util.spec_from_file_location("mg_saic_logic", MODULE_PATH)
+LOGIC = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(LOGIC)
+
+
+class NormalizeSunroofActionTests(unittest.TestCase):
+    def test_accepts_boolean_true(self):
+        self.assertEqual(LOGIC.normalize_sunroof_action(True), (True, "open"))
+
+    def test_accepts_boolean_false(self):
+        self.assertEqual(LOGIC.normalize_sunroof_action(False), (False, "close"))
+
+    def test_accepts_string(self):
+        self.assertEqual(LOGIC.normalize_sunroof_action("open"), (True, "open"))
+
+    def test_rejects_invalid_value(self):
+        with self.assertRaises(ValueError):
+            LOGIC.normalize_sunroof_action("tilt")
+
+
+class SelectUpdateIntervalTests(unittest.TestCase):
+    def setUp(self):
+        self.default_interval = timedelta(minutes=30)
+        self.powered_interval = timedelta(minutes=1)
+        self.charging_interval = timedelta(minutes=5)
+        self.grace_interval = timedelta(minutes=10)
+        self.after_shutdown_interval = timedelta(minutes=20)
+
+    def select_interval(self, **kwargs):
+        return LOGIC.select_update_interval(
+            default_update_interval=self.default_interval,
+            powered_update_interval=self.powered_interval,
+            charging_update_interval=self.charging_interval,
+            grace_period_update_interval=self.grace_interval,
+            after_shutdown_update_interval=self.after_shutdown_interval,
+            **kwargs,
+        )
+
+    def test_prefers_powered_interval(self):
+        interval = self.select_interval(
+            is_powered_on=True,
+            is_charging=False,
+            idle_duration=timedelta(hours=1),
+            activity_duration=timedelta(hours=1),
+        )
+        self.assertEqual(interval, self.powered_interval)
+
+    def test_prefers_charging_interval(self):
+        interval = self.select_interval(
+            is_powered_on=False,
+            is_charging=True,
+            idle_duration=timedelta(hours=1),
+            activity_duration=timedelta(hours=1),
+        )
+        self.assertEqual(interval, self.charging_interval)
+
+    def test_uses_grace_period_interval_for_recent_activity(self):
+        interval = self.select_interval(
+            is_powered_on=False,
+            is_charging=False,
+            idle_duration=timedelta(hours=1),
+            activity_duration=timedelta(minutes=5),
+        )
+        self.assertEqual(interval, self.grace_interval)
+
+    def test_uses_after_shutdown_interval_before_default(self):
+        interval = self.select_interval(
+            is_powered_on=False,
+            is_charging=False,
+            idle_duration=timedelta(minutes=15),
+            activity_duration=timedelta(hours=1),
+        )
+        self.assertEqual(interval, self.after_shutdown_interval)
+
+    def test_preserves_user_default_interval_when_idle(self):
+        interval = self.select_interval(
+            is_powered_on=False,
+            is_charging=False,
+            idle_duration=timedelta(hours=1),
+            activity_duration=timedelta(hours=1),
+        )
+        self.assertEqual(interval, self.default_interval)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Review Fixes - 2026-03-21

This note documents the fixes applied after the repository review and explains
why each change was made.

## 1. Non-blocking action refresh scheduling

Files:
- `custom_components/mg_saic/coordinator.py`

What changed:
- Replaced the blocking `schedule_action_refresh()` implementation with a
  background task.
- Added task cancellation and coordinator shutdown cleanup.

Why:
- The previous implementation awaited multiple `sleep()` calls directly inside
  service/entity actions. A lock, climate or charging command could therefore
  remain pending for minutes before returning control to Home Assistant.
- The new version schedules the follow-up refresh sequence in the background,
  keeps only one active action-refresh sequence per coordinator and cancels it
  safely when the entry is unloaded.

## 2. Correct multi-VIN service routing

Files:
- `custom_components/mg_saic/__init__.py`
- `custom_components/mg_saic/services.py`

What changed:
- Added `clients_by_vin` alongside `coordinators_by_vin`.
- Registered services only once for the integration domain.
- Updated every service handler to resolve the correct client/coordinator from
  the VIN provided in the service call.

Why:
- Services were previously registered once per config entry and closed over the
  client/coordinator of that entry. With multiple vehicles, the global service
  handlers could operate on the wrong coordinator and refresh the wrong VIN.
- Resolving resources by VIN at call time makes service behavior deterministic.

## 3. Proper unload and resource cleanup

Files:
- `custom_components/mg_saic/__init__.py`
- `custom_components/mg_saic/coordinator.py`
- `custom_components/mg_saic/api.py`

What changed:
- Removed entry-specific client and coordinator objects on unload.
- Removed VIN indexes on unload.
- Added coordinator shutdown logic to cancel background tasks and scheduled
  refresh callbacks.
- Closed the API client cleanly and made `close()` tolerate an uninitialized
  session.

Why:
- The previous unload path left stale coordinators behind and could keep the
  service registry alive even when the integration had no remaining entries.
- Cleaning the coordinator tasks and API client prevents leaked callbacks and
  stale references.

## 4. Heated seats service and switch fixes

Files:
- `custom_components/mg_saic/services.py`
- `custom_components/mg_saic/services.yaml`
- `custom_components/mg_saic/switch.py`

What changed:
- Aligned the service schema with the documented `left_level` and
  `right_level` fields.
- Fixed the heated seat switch constructor to use stable seat identifiers.
- Mapped each heated seat switch to the correct status attribute from the
  vehicle payload.

Why:
- The service schema and service handler disagreed about the accepted payload.
- The seat switches used inconsistent identifiers and therefore never reached
  the branch that sends the command, while also reading the wrong status field.

## 5. Sunroof service compatibility

Files:
- `custom_components/mg_saic/api.py`
- `custom_components/mg_saic/services.py`

What changed:
- Made `control_sunroof()` accept either a boolean or an `"open"/"close"`
  string and normalize both forms internally.

Why:
- The service layer passed a boolean while the API wrapper expected a string,
  which could invert behavior and always resolve to closing the sunroof.

## 6. Preserve the configured default polling interval

Files:
- `custom_components/mg_saic/coordinator.py`

What changed:
- Added a dedicated `default_update_interval`.
- Reused that value whenever the vehicle returns to the idle/default polling
  state.

Why:
- The previous logic fell back to the constant `UPDATE_INTERVAL`, which meant a
  user-defined polling interval was silently lost after state transitions.

## 7. API errors now propagate to callers

Files:
- `custom_components/mg_saic/api.py`

What changed:
- Re-raised exceptions in `lock_vehicle()`, `unlock_vehicle()` and
  `open_tailgate()`.

Why:
- The service/entity layers were able to log success after a failed API call
  because those methods swallowed the exception after logging it once.

## Validation performed

- `python3 -m compileall custom_components/mg_saic`
- `python3 -m unittest discover -s tests -p "test_*.py"`

## 8. Lightweight automated tests

Files:
- `custom_components/mg_saic/logic.py`
- `tests/test_logic.py`
- `.github/workflows/python-tests.yaml`

What changed:
- Extracted pure helper logic for sunroof normalization and update interval
  selection.
- Added standard-library unit tests for these rules.
- Added a CI workflow to run the tests on pushes and pull requests.

Why:
- The repository only had HACS and Hassfest validation. These new tests cover
  two regression-prone code paths without requiring a full Home Assistant test
  harness.

## Remaining gap

- The repository still does not include end-to-end Home Assistant tests for the
  config flow, entity lifecycle and service registration. The most critical
  pure logic now has automated coverage, but runtime HA integration coverage is
  still a future improvement.
