### PR TITLE
Release v1.0.0

### DIFF
--- a/custom_components/mg_saic/api.py
+++ b/custom_components/mg_saic/api.py
@@ -150,6 +150,54 @@ class SAICMGAPIClient:
             LOGGER.error(f"Error triggering alarm for VIN {vin}: {e}")
             raise
 
+    # MESSAGE QUEUE / EVENT POLLING
+
+    async def get_alarm_messages(self, page_num: int = 1, page_size: int = 10):
+        """Retrieve alarm messages from the SAIC message queue.
+
+        Used to detect vehicle events (engine start, shutdown, charging)
+        without polling the full vehicle status endpoint on a fixed interval.
+        Returns a MessageResp object with a .messages list of MessageEntity.
+        """
+        try:
+            result = await self._make_api_call(
+                self.saic_api.get_alarm_list,
+                page_num=page_num,
+                page_size=page_size,
+            )
+            return result
+        except Exception as e:
+            LOGGER.warning("Error retrieving alarm messages: %s", e)
+            return None
+
+    async def set_alarm_switches(self, vin: str) -> None:
+        """Register alarm switch subscriptions with the SAIC API.
+
+        Tells the SAIC server to queue alarm messages for this account/VIN
+        when key vehicle events occur. Uses all alarm types supported by the
+        saic-python-client-ng AlarmType enum. Call once during coordinator setup.
+        """
+        try:
+            from saic_ismart_client_ng.api.vehicle.alarm import AlarmType
+            alarm_switches = list(AlarmType)
+            await self._make_api_call(
+                self.saic_api.set_alarm_switches,
+                alarm_switches=alarm_switches,
+                vin=vin,
+            )
+            LOGGER.debug(
+                "Registered alarm switches for VIN %s: %s",
+                vin,
+                [a.name for a in alarm_switches],
+            )
+        except Exception as e:
+            LOGGER.warning(
+                "Could not register alarm switches for VIN %s: %s — "
+                "message-driven updates may not function.",
+                vin,
+                e,
+            )
+
     # CHARGING CONTROL
     async def send_vehicle_charging_control(self, vin, action):
         """Send a charging control command to the vehicle."""

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -8,6 +8,39 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util.dt import utcnow
 from .api import SAICMGAPIClient
 from .logic import select_update_interval
+
+# ── Message-driven update constants ─────────────────────────────────────────
+# How often to poll the SAIC alarm message queue (seconds).
+# 60s matches the MQTT gateway default; the message queue is lightweight —
+# it queries SAIC's server, not the car's telematics module directly.
+MESSAGE_POLL_INTERVAL_SECONDS = 60
+
+# messageType string that indicates a vehicle start / engine-on event.
+# Confirmed from saic-python-mqtt-gateway source (messageType "323").
+MESSAGE_TYPE_VEHICLE_START = "323"
+
+# Keywords in message title/content indicating vehicle shutdown (offCar).
+# The new REST API does not expose a distinct messageType for shutdown,
+# so we infer from message text.
+SHUTDOWN_TITLE_KEYWORDS = [
+    "vehicle off", "car off", "turned off", "engine off", "ignition off",
+    "vehicle stopped", "parked",
+]
+
+# Keywords indicating a charging / plug-in event.
+CHARGING_TITLE_KEYWORDS = [
+    "charging", "charge", "plugged", "connected to charger",
+    "charging started", "ev connected",
+]
+
+# After the car turns off, fire extra refreshes at these intervals (seconds)
+# to catch plug-in as quickly as possible. The coordinator is still on its
+# 15-min powered poll cycle when shutdown occurs, so without this we'd wait
+# up to 15 minutes before detecting plug-in.
+# The sequence exits early as soon as is_charging is detected, so a long
+# sequence costs nothing if you plug in quickly.
+# Sequence: 1min, 3min, 7min, 15min, 25min → catches plug-in within ~1-25 minutes.
+POST_SHUTDOWN_REFRESH_SEQUENCE = [60, 120, 240, 480, 600]
 from .const import (
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CHARGING_STATUS_CODES,
@@ -71,6 +104,14 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         self.next_update_time = None
         self._action_refresh_task = None
         self._action_refresh_generation = 0
+
+        # Message queue polling state
+        self._message_poll_task: asyncio.Task | None = None
+        self._last_seen_message_id: str | int | None = None
+        self._last_seen_message_ts = None
+
+        # Post-shutdown rapid refresh state
+        self._shutdown_refresh_task: asyncio.Task | None = None
 
         # Initialize with default values
         self.vehicle_series = None
@@ -417,6 +458,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.is_initial_setup = False
 
+        # Register alarm switches so SAIC server queues event messages for us
+        await self.client.set_alarm_switches(vin=self.vin)
+
+        # Start the background message-queue polling loop
+        await self._start_message_polling()
+
         return True
 
     async def _async_update_data(self):
@@ -528,6 +575,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 if self.is_powered_on:
                     self.last_powered_off_time = datetime.now(timezone.utc)
+                    LOGGER.info(
+                        "Vehicle powered off detected for VIN %s — "
+                        "starting post-shutdown refresh sequence",
+                        self.vin,
+                    )
+                    self._start_shutdown_refresh_sequence()
                 self.is_powered_on = False
 
             # Detect vehicle activity
@@ -662,9 +715,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             after_shutdown_update_interval=self.after_shutdown_update_interval,
         )
 
-        if self.update_interval == self.powered_update_interval:
+        if self.is_powered_on:
             LOGGER.debug("Vehicle is powered on. Using powered update interval.")
-        elif self.update_interval == self.charging_update_interval:
+        elif self.is_charging:
             LOGGER.debug("Vehicle is charging. Using charging update interval.")
         elif self.update_interval == self.grace_period_update_interval:
             LOGGER.debug("Within grace period. Using grace period interval.")
@@ -738,8 +791,255 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 self._action_refresh_task = None
                 self._adjust_update_interval()
 
+
+    # ── Post-shutdown rapid refresh sequence ─────────────────────────────────
+
+    def _start_shutdown_refresh_sequence(self) -> None:
+        """Kick off a background task that polls rapidly after engine-off.
+
+        Because the SAIC REST API has no dedicated shutdown alarm type, the
+        coordinator may not poll again for up to 15 minutes after the car
+        turns off (it was on the powered-on interval). This sequence fires
+        a series of extra refreshes at POST_SHUTDOWN_REFRESH_SEQUENCE intervals
+        so that plug-in events are detected within ~1-5 minutes.
+        """
+        # Cancel any existing shutdown refresh from a previous cycle
+        if self._shutdown_refresh_task and not self._shutdown_refresh_task.done():
+            self._shutdown_refresh_task.cancel()
+
+        self._shutdown_refresh_task = self.config_entry.async_create_background_task(
+            self.hass,
+            self._run_shutdown_refresh_sequence(),
+            f"mg_saic_shutdown_refresh_{self.vin}",
+        )
+
+    async def _run_shutdown_refresh_sequence(self) -> None:
+        """Run the post-shutdown refresh sequence."""
+        try:
+            for delay in POST_SHUTDOWN_REFRESH_SEQUENCE:
+                await asyncio.sleep(delay)
+                LOGGER.info(
+                    "Post-shutdown refresh for VIN %s (delay was %ds)",
+                    self.vin,
+                    delay,
+                )
+                await self.async_request_refresh()
+                # If the car is now charging, the coordinator interval will have
+                # already switched to charging interval — we can stop early.
+                if self.is_charging:
+                    LOGGER.info(
+                        "Charging detected for VIN %s — ending post-shutdown sequence",
+                        self.vin,
+                    )
+                    break
+        except asyncio.CancelledError:
+            LOGGER.debug(
+                "Post-shutdown refresh sequence cancelled for VIN %s", self.vin
+            )
+            raise
+        finally:
+            self._shutdown_refresh_task = None
+
+    # ── Message queue polling (event-driven updates) ─────────────────────────
+
+    async def _start_message_polling(self) -> None:
+        """Start the background task that polls the SAIC alarm message queue."""
+        if self._message_poll_task and not self._message_poll_task.done():
+            LOGGER.debug("Message poll task already running for VIN %s", self.vin)
+            return
+        LOGGER.debug(
+            "Starting message poll loop for VIN %s (interval: %ds)",
+            self.vin,
+            MESSAGE_POLL_INTERVAL_SECONDS,
+        )
+        self._message_poll_task = self.config_entry.async_create_background_task(
+            self.hass,
+            self._message_poll_loop(),
+            f"mg_saic_message_poll_{self.vin}",
+        )
+
+    async def _stop_message_polling(self) -> None:
+        """Stop the background message poll task."""
+        if self._message_poll_task and not self._message_poll_task.done():
+            LOGGER.debug("Stopping message poll task for VIN %s", self.vin)
+            self._message_poll_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._message_poll_task
+        self._message_poll_task = None
+
+    async def _message_poll_loop(self) -> None:
+        """Poll the SAIC alarm message queue periodically and react to events."""
+        # Initial delay so startup does not pile on to the first coordinator refresh
+        await asyncio.sleep(MESSAGE_POLL_INTERVAL_SECONDS)
+        while True:
+            try:
+                await self._check_alarm_messages()
+            except asyncio.CancelledError:
+                LOGGER.debug("Message poll loop cancelled for VIN %s", self.vin)
+                raise
+            except Exception as e:
+                LOGGER.warning(
+                    "Message poll loop error for VIN %s: %s", self.vin, e
+                )
+            await asyncio.sleep(MESSAGE_POLL_INTERVAL_SECONDS)
+
+    async def _check_alarm_messages(self) -> None:
+        """Check the SAIC alarm message queue and force a refresh on key events.
+
+        Paginates through the message queue (page_size=1, like the MQTT gateway)
+        until we reach a message we have already seen, collecting all new messages.
+        Triggers an immediate coordinator refresh when significant vehicle events
+        are detected:
+        - Engine start (messageType 323) → refresh to capture driving state
+        - Vehicle shutdown (offCar) → refresh to capture final parked state
+        - Charging started (plug-in) → refresh to update charging state
+        """
+        all_new_messages = []
+        page = 1
+        max_pages = 20  # Safety limit
+
+        while page <= max_pages:
+            try:
+                response = await self.client.get_alarm_messages(
+                    page_num=page, page_size=1
+                )
+            except Exception as e:
+                LOGGER.warning(
+                    "Failed to fetch alarm messages (page %d) for VIN %s: %s",
+                    page, self.vin, e,
+                )
+                break
+
+            if response is None or not getattr(response, "messages", None):
+                break
+
+            msg = response.messages[0]
+
+            # Skip messages for other VINs
+            if msg.vin and msg.vin != self.vin:
+                page += 1
+                continue
+
+            # Stop when we reach a message we have already seen
+            if msg.messageId is not None and msg.messageId == self._last_seen_message_id:
+                break
+
+            # Stop when we reach a message older than our last seen timestamp
+            if (
+                self._last_seen_message_ts is not None
+                and msg.message_time is not None
+                and msg.message_time <= self._last_seen_message_ts
+            ):
+                break
+
+            all_new_messages.append(msg)
+            page += 1
+
+        if not all_new_messages:
+            LOGGER.debug("No new alarm messages since last check for VIN %s", self.vin)
+            return
+
+        # On first run, just record where we are — do NOT act on historical messages.
+        # This prevents a burst of spurious refreshes every time HA restarts.
+        if self._last_seen_message_id is None:
+            latest = all_new_messages[0]
+            self._last_seen_message_id = latest.messageId
+            self._last_seen_message_ts = latest.message_time
+            LOGGER.debug(
+                "First message queue check for VIN %s — recording latest id=%s, "
+                "skipping %d historical message(s)",
+                self.vin,
+                latest.messageId,
+                len(all_new_messages),
+            )
+            return
+
+        LOGGER.info(
+            "%d new alarm message(s) detected for VIN %s",
+            len(all_new_messages),
+            self.vin,
+        )
+
+        # Record the latest (newest) message we have now seen
+        latest = all_new_messages[0]
+        self._last_seen_message_id = latest.messageId
+        self._last_seen_message_ts = latest.message_time
+
+        should_force_refresh = False
+        refresh_reason = None
+
+        for msg in all_new_messages:
+            title = (msg.title or "").lower()
+            content_text = (msg.content or "").lower()
+            msg_type = msg.messageType or ""
+
+            LOGGER.debug(
+                "Alarm message for VIN %s: type=%s id=%s title=%s",
+                self.vin,
+                msg_type,
+                msg.messageId,
+                msg.title,
+            )
+
+            # Engine start (highest priority — break immediately)
+            if msg_type == MESSAGE_TYPE_VEHICLE_START or any(
+                kw in title for kw in ["start", "engine on", "ignition on", "power on"]
+            ):
+                LOGGER.info(
+                    "Engine start event for VIN %s (type=%s title='%s')",
+                    self.vin,
+                    msg_type,
+                    msg.title,
+                )
+                should_force_refresh = True
+                refresh_reason = "engine start"
+                break
+
+            # Vehicle shutdown / offCar equivalent
+            if any(kw in title for kw in SHUTDOWN_TITLE_KEYWORDS) or any(
+                kw in content_text for kw in SHUTDOWN_TITLE_KEYWORDS
+            ):
+                LOGGER.info(
+                    "Vehicle shutdown event for VIN %s (title='%s')",
+                    self.vin,
+                    msg.title,
+                )
+                should_force_refresh = True
+                refresh_reason = "vehicle shutdown"
+
+            # Charging / plug-in event
+            if any(kw in title for kw in CHARGING_TITLE_KEYWORDS) or any(
+                kw in content_text for kw in CHARGING_TITLE_KEYWORDS
+            ):
+                LOGGER.info(
+                    "Charging/plug-in event for VIN %s (title='%s')",
+                    self.vin,
+                    msg.title,
+                )
+                should_force_refresh = True
+                refresh_reason = (
+                    f"{refresh_reason} + charging"
+                    if refresh_reason
+                    else "charging detected"
+                )
+
+        if should_force_refresh:
+            LOGGER.info(
+                "Forcing coordinator refresh for VIN %s — reason: %s",
+                self.vin,
+                refresh_reason,
+            )
+            await self.async_request_refresh()
+
     async def async_shutdown(self):
         """Release coordinator resources when the entry is unloaded."""
+        # Stop background tasks before anything else
+        await self._stop_message_polling()
+        if self._shutdown_refresh_task and not self._shutdown_refresh_task.done():
+            self._shutdown_refresh_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._shutdown_refresh_task
+
         self._action_refresh_generation += 1
 
         if self._action_refresh_task and not self._action_refresh_task.done():

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -113,6 +113,10 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # Post-shutdown rapid refresh state
         self._shutdown_refresh_task: asyncio.Task | None = None
 
+        # Track previous powered-on state so we detect the transition even
+        # when status_data is None (generic response during power-down)
+        self._prev_is_powered_on: bool = False
+
         # Initialize with default values
         self.vehicle_series = None
         self.min_temp = 16  # Default fallback
@@ -568,6 +572,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             power_mode = getattr(basic_status, "powerMode", None)
 
             # Detect Power State
+            # Track previous state so we catch the transition even if a prior
+            # poll returned None (generic response during power-down window)
+            self._prev_is_powered_on = self.is_powered_on
             if power_mode in [2, 3]:
                 if not self.is_powered_on:
                     self.last_powered_on_time = datetime.now(timezone.utc)
@@ -594,6 +601,25 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 self.is_charging = (
                     getattr(chrg_mgmt_data, "bmsChrgSts", None) in CHARGING_STATUS_CODES
                 )
+
+        # Missed-transition guard: if vehicle status was unavailable (None) but
+        # charging data confirms the car is now charging, we know the car must
+        # have powered off. Fire the shutdown sequence if we haven't already.
+        if (
+            not status_data
+            and self.is_charging
+            and self._prev_is_powered_on
+            and self.is_powered_on  # still True because status block was skipped
+        ):
+            if self._shutdown_refresh_task is None or self._shutdown_refresh_task.done():
+                LOGGER.info(
+                    "Charging detected after status unavailable for VIN %s — "
+                    "inferring shutdown, starting post-shutdown refresh sequence",
+                    self.vin,
+                )
+                self.last_powered_off_time = datetime.now(timezone.utc)
+                self.is_powered_on = False
+                self._start_shutdown_refresh_sequence()
 
         # Update activity timestamp
         if recent_activity:

--- a/custom_components/mg_saic/device_tracker.py
+++ b/custom_components/mg_saic/device_tracker.py
@@ -1,6 +1,6 @@
 # File: device_tracker.py
 
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, LOGGER
 from .utils import create_device_info

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ad-ha/mg-saic-ha/issues",
   "requirements": ["requests", "pycryptodome", "saic-ismart-client-ng==0.9.3"],
-  "version": "0.9.10-beta"
+  "version": "1.0.0"
 }
 

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ad-ha/mg-saic-ha/issues",
   "requirements": ["requests", "pycryptodome", "saic-ismart-client-ng==0.9.3"],
-  "version": "0.9.8"
+  "version": "0.9.9-beta"
 }
 

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ad-ha/mg-saic-ha/issues",
   "requirements": ["requests", "pycryptodome", "saic-ismart-client-ng==0.9.3"],
-  "version": "0.9.9-beta"
+  "version": "0.9.10-beta"
 }
 

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -604,10 +604,6 @@ class SAICMGMileageSensor(CoordinatorEntity, SensorEntity):
         self._device_info = create_device_info(coordinator, entry.entry_id)
         self._vehicle_type = coordinator.vehicle_type
 
-        # Retain last valid temperature readings so the sensor does not drop
-        # to unknown when the API returns -128 (deep sleep / unavailable).
-        self._last_valid_temperature: dict[str, float] = {}
-
     @property
     def unique_id(self):
         return self._unique_id
@@ -704,6 +700,10 @@ class SAICMGVehicleSensor(CoordinatorEntity, SensorEntity):
         self._unique_id = f"{entry.entry_id}_{vin_info.vin}_{field}"
 
         self._device_info = create_device_info(coordinator, entry.entry_id)
+
+        # Retain last valid temperature readings so the sensor does not drop
+        # to unknown when the API returns -128 (deep sleep / unavailable).
+        self._last_valid_temperature: dict[str, float] = {}
 
     @property
     def unique_id(self):

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -604,6 +604,10 @@ class SAICMGMileageSensor(CoordinatorEntity, SensorEntity):
         self._device_info = create_device_info(coordinator, entry.entry_id)
         self._vehicle_type = coordinator.vehicle_type
 
+        # Retain last valid temperature readings so the sensor does not drop
+        # to unknown when the API returns -128 (deep sleep / unavailable).
+        self._last_valid_temperature: dict[str, float] = {}
+
     @property
     def unique_id(self):
         return self._unique_id
@@ -732,10 +736,18 @@ class SAICMGVehicleSensor(CoordinatorEntity, SensorEntity):
                             and raw_value == -128
                         ):
                             LOGGER.debug(
-                                "Sensor %s has invalid temperature value -128",
+                                "Sensor %s has invalid temperature value -128, "
+                                "retaining last valid value",
                                 self._name,
                             )
-                            return None
+                            return self._last_valid_temperature.get(self._field)
+                        # Store valid temperature readings for retention
+                        if self._field in [
+                            "interiorTemperature", "exteriorTemperature"
+                        ]:
+                            self._last_valid_temperature[self._field] = (
+                                raw_value * self._factor
+                            )
                         # Add mapping for powerMode
                         if self._field == "powerMode":
                             return {


### PR DESCRIPTION
## v1.0.0 (from beta v0.9.9 and v0.9.10)

This release brings event-driven vehicle state updates, temperature sensor
improvements, a deprecation fix for upcoming HA Core versions, and several
bug fixes accumulated during the beta period.

---

### 🚀 New: Event-driven vehicle updates

Previously, HA could take up to 60 minutes to reflect a change in vehicle
state (engine on, engine off, plugged in to charge). This release closes
that gap significantly across all state transitions.

**Engine start** is now detected via the SAIC alarm message queue, which is
polled every 60 seconds in a lightweight background task. When a Vehicle
Start message arrives (message type 323), an immediate full coordinator
refresh is triggered. In practice, HA reflects the powered-on state within
about 60 seconds of the car starting — without waiting for the next
scheduled poll.

**Shutdown and plug-in** are detected via a post-shutdown refresh sequence.
When the coordinator detects the car has powered off, it automatically fires
a series of extra refreshes at approximately 1, 3, 7, 15, and 25 minutes
after shutdown. This ensures plug-in events are captured quickly. The
sequence exits early as soon as charging is confirmed, so if you plug in
promptly after parking, HA will reflect it within 1–3 minutes.

A **missed-transition guard** handles the edge case where the car powers
down while simultaneously connecting to the charger. In this scenario
SAIC's API temporarily returns incomplete responses, which would previously
prevent the shutdown from being detected at all. The guard detects the
situation via charging data and correctly infers the shutdown.

A **first-run guard** ensures that historical messages already in the SAIC
queue at HA startup are not acted upon, preventing spurious forced refreshes
every time HA restarts.

> All new polling queries SAIC's cloud servers only. The car's telematics
> module is not directly contacted and there is no risk of 12V battery drain.

---

### 🐛 Bug fixes

**Temperature sensors no longer show unknown during deep sleep**

When the car enters deep sleep, the SAIC API returns -128 for
`exteriorTemperature` and `interiorTemperature`. Previously this caused
both sensors to drop to `unknown`, creating gaps in dashboards and graph
history. Both sensors now retain the last valid reading when -128 is
received, keeping graphs continuous overnight and during extended parking.

**Interval logging false positive fixed**

The log previously reported "Vehicle is charging. Using charging update
interval" incorrectly when the vehicle was actually in the post-shutdown
grace period. This was caused by `charging_update_interval` and
`after_shutdown_update_interval` both defaulting to 10 minutes, making them
indistinguishable by value comparison. The logging now checks `is_charging`
and `is_powered_on` state flags directly.

**`device_tracker.py` deprecation warning resolved**

Updated the `TrackerEntity` import to use the current non-deprecated path
`homeassistant.components.device_tracker.TrackerEntity`, resolving the
following warning which would become an error in HA Core 2027.6:
> The deprecated alias TrackerEntity was used from mg_saic. It will be
> removed in HA Core 2027.6.

---

### ⚠️ Known issues (pre-existing, not introduced in this release)

**Excessive retry logging during charging sessions** — a logic bug in the
generic response detection method can incorrectly flag valid responses as
generic when the mileage field is zero (which occurs legitimately at the
start of a charge session). This triggers the full 5-retry cycle
unnecessarily and produces warning log entries. It does not affect
functionality and will be addressed in a future release.

**Instant Power sensor error when vehicle status unavailable** — when the
vehicle status endpoint returns no data after all retries (typically due to
poor mobile signal), the Instant Power sensor logs an error. Sensor values
recover once connectivity is restored. Will be addressed in a future release.

---

### 📋 Files changed

- `custom_components/mg_saic/api.py`
- `custom_components/mg_saic/coordinator.py`
- `custom_components/mg_saic/sensor.py`
- `custom_components/mg_saic/device_tracker.py`
- `custom_components/mg_saic/manifest.json`

---

### 🙏 Contributors

Thanks to @townsmcp for the extensive real-world testing across multiple
drive cycles that validated the event-driven update behaviour, and for
taking on maintenance of this integration.