### PR TITLE
1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 ### CLIMATE
 - AC Control Climate entity
   * Temperature
-  * Fan Speed
-  * HVAC mode (Cool / Fan Only / Off)
+  * Fan Speed *(most models)* **or** HVAC mode + Preset *(mode-select models, e.g. MG S9 PHEV — see [Climate Control](#climate-control))*
+  * HVAC mode (Cool / Fan Only / Off, plus Heat on mode-select models)
 ### SLIDERS
 - Target SOC *(shown only on models where the iSmart app supports it)*
 ### SELECT
@@ -186,24 +186,34 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
  
 The MG SAIC integration exposes a climate entity for remote control of the vehicle's air conditioning. Because SAIC limits remote commands to **3 per cycle between starting the car with a key**, the integration is designed to use commands as efficiently as possible.
  
+### Two control schemes
+ 
+Not all MG models expose climate control the same way, so the integration uses one of two schemes depending on your vehicle:
+ 
+- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes. This is the default and covers the MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
+- **Mode-select models (e.g. MG S9 PHEV):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle.
+ 
 ### How commands are used
  
-The SAIC API counts each instruction sent to the car as one command. To avoid wasting your allowance, only explicit HVAC mode changes send a command. Adjusting fan speed or temperature on their own does not.
+The SAIC API counts each instruction sent to the car as one command. To avoid wasting your allowance, only explicit HVAC mode or preset changes send a command. Adjusting fan speed or temperature on their own does not.
  
 **Uses a command:**
-- Turning the AC on (HVAC mode set to `Cool` or `Fan Only`)
+- Turning the AC on (HVAC mode set to `Cool`, `Fan Only`, or `Heat`)
 - Turning the AC off (HVAC mode set to `Off`)
-- Switching between `Cool` and `Fan Only`
+- Switching between HVAC modes
+- Selecting a preset (`Max Cool` / `Defrost`) on mode-select models
 **Does NOT use a command:**
-- Changing fan speed (`Low`, `Medium`, `High`)
+- Changing fan speed (`Low`, `Medium`, `High`) on fan-speed models
 - Changing target temperature
 ### Recommended usage
  
-Set your preferred temperature and fan speed **first**, then turn the AC on. The command sent to the car will include whatever fan speed and temperature you have already set in HA. A complete remote pre-conditioning session uses exactly **2 commands** — one to turn on, one to turn off — leaving one spare for a lock or unlock action.
+Set your preferred temperature (and fan speed, on fan-speed models) **first**, then turn the AC on. The command sent to the car will include whatever settings you have already applied in HA. A complete remote pre-conditioning session uses exactly **2 commands** — one to turn on, one to turn off — leaving one spare for a lock or unlock action.
  
-If you want to change temperature or fan speed while the AC is already running, update the values in HA first, then turn the AC off and back on. This applies your new settings using 2 commands.
+If you want to change settings while the AC is already running, update the values in HA first, then turn the AC off and back on. This applies your new settings using 2 commands.
  
-### Fan speeds
+### Fan-speed models
+ 
+**Fan speeds**
  
 | HA setting | Behaviour |
 |---|---|
@@ -213,13 +223,28 @@ If you want to change temperature or fan speed while the AC is already running, 
  
 > **Note:** Fan speed values used internally vary by vehicle model. The integration automatically selects the correct values for your car based on its series. The Front Defrost command uses a separate API speed value and is never accidentally triggered by fan speed changes.
  
-### HVAC modes
+**HVAC modes**
  
 | Mode | Behaviour |
 |---|---|
 | `Cool` | Runs the compressor with your chosen temperature and fan speed |
 | `Fan Only` | Runs the fan without the compressor (blowing only) |
 | `Off` | Stops all climate activity |
+ 
+### Mode-select models (e.g. MG S9 PHEV)
+ 
+On these models there is **no fan-speed slider** — the car manages its own fan. Control is via HVAC modes and presets instead:
+ 
+| Mode / Preset | Behaviour |
+|---|---|
+| HVAC `Cool` | AC on, automatic fan, follows your target temperature |
+| HVAC `Heat` | Heating |
+| HVAC `Fan Only` | Fan without the compressor |
+| HVAC `Off` | Stops all climate activity |
+| Preset `Max Cool` | Strong fixed-fan fast cool-down |
+| Preset `Defrost` | Windscreen / upper-vent defrost |
+ 
+> **⚠️ Note for MG S9 PHEV owners:** from **1.1.2** this model uses the mode-select scheme. The previous Low/Med/High fan control has been replaced by the HVAC modes and presets above. If you have automations or scripts that called `climate.set_fan_mode` on your S9 PHEV, update them to use `climate.set_hvac_mode` (`cool` / `heat` / `fan_only`) or `climate.set_preset_mode` (`Max Cool` / `Defrost`) instead.
  
  
 ## Event-Driven Updates

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 # MG/SAIC CUSTOM INTEGRATION
 
 <a href="https://buymeacoffee.com/Townsmcp" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
-
+ 
 **Important Notes:** 
 - **Using this integration causes the MG/SAIC mobile app to shut down if the same account is used, as per API requirements.**
 - **To avoid issues, make sure to setup a Secondary Account on iSmart App.**
@@ -23,42 +23,36 @@
 **Requirements:**
 - Home Assistant 2024.06 or later.
 - Confirmed compatible with Python 3.14, the runtime used by current Home Assistant core releases (2026.3+). No action needed on your part this is handled automatically by Home Assistant on supported installation methods.
-
 ## INSTALLATION
-
+ 
 ### HACS (Home Assistant Community Store)
-
+ 
 1. Ensure that HACS is installed.
 2. Go to HACS
 3. Search for "MG SAIC" and download the repository.
 4. Restart Home Assistant.
-
 ### Manual Installation
-
+ 
 1. Download the latest release from the [MG SAIC Custom Integration GitHub repository](https://github.com/townsmcp/mg-saic-ha/releases).
 2. Unzip the release and copy the `mg_saic` directory to `custom_components` in your Home Assistant configuration directory.
 3. Restart Home Assistant.
-
 ## CONFIGURATION
-
+ 
 To add the integration to your local Home Assistant, click here:
-
+ 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=townsmcp&repository=mg-saic-ha&category=integration)
-
+ 
 Install the integration, restart Home Assistant and then add the integration, either:
-
+ 
 [<img src="https://github.com/user-attachments/assets/36459daa-a780-448a-82a5-19ee07ccd3f6">](https://my.home-assistant.io/redirect/config_flow_start?domain=mg_saic)
-
+ 
 Or manually by:
-
+ 
 1. Go to Configuration -> Integrations.
 2. Click on the "+ Add Integration" button.
 3. Search for "MG SAIC" and follow the instructions to set up the integration.
 4. Select your type of account (email or phone), enter the details and select your region (EU, China, Australia, Turkey, Rest of World)
 5. Once connected to the API, a list of available VINs associated with your account will be shown. Select the vehicle that you want to integrate and finish the process.
-
-
-
 You may add additional vehicles by following the same steps as above.
  
 ### Multiple Vehicles
@@ -66,11 +60,13 @@ You may add additional vehicles by following the same steps as above.
 If you have more than one MG/SAIC vehicle, you can add each one as a separate integration entry. Vehicles on the **same SAIC account** are fully supported — the integration uses a single shared API session per account, so adding a second vehicle does not interfere with the first.
  
 If your vehicles are on different SAIC accounts, add each account separately in the same way.
-
-
+ 
+ 
 ## SENSORS AVAILABLE
  
 The MG/SAIC Custom Integration provides the following sensors, binary sensors, and controls. Not all entities are available on every vehicle — availability depends on vehicle type (BEV, PHEV, HEV, ICE) and optional equipment.
+ 
+> **Looking for what "on"/"off" or a particular sensor value actually means?** See the [Entity States Reference](#entity-states-reference) section below — it lists every possible state for every status and control entity.
  
 ### SENSORS
  
@@ -78,10 +74,11 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Brand
 - Model
 - Model Year
+- VIN *(displayed masked, e.g. `LS**********46986`; the full VIN is available as the `vin_full` attribute for use in automations/services)*
 - Mileage
 - Interior Temperature
 - Exterior Temperature
-- Battery Voltage (12V)
+- Ancillary Battery Voltage *(12V battery)*
 - Speed
 - Power Mode
 - Last Key Seen *(raw key fob identifier; shown as Unknown when key is not present)*
@@ -91,21 +88,21 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Last Update Time
 - Next Update Time
 #### Tyre Pressure
-- Front Left Tyre Pressure
-- Front Right Tyre Pressure
-- Rear Left Tyre Pressure
-- Rear Right Tyre Pressure
+- Tyre Pressure Front Left
+- Tyre Pressure Front Right
+- Tyre Pressure Rear Left
+- Tyre Pressure Rear Right
 #### Electric / Hybrid
-- EV State of Charge (SOC)
+- State of Charge (SOC)
 - Electric Range
 - Instant Power *(kW draw/regen while driving; negative = traction, positive = regen/charge)*
 - Fuel Level *(PHEV/HEV/ICE only)*
 - Fuel Range *(PHEV/HEV/ICE only)*
 #### Climate
-- HVAC Status
 - Front Left Heated Seat Level *(if equipped)*
 - Front Right Heated Seat Level *(if equipped)*
 - Steering Wheel Heat *(if equipped)*
+  *(Note: the AC/HVAC running state itself is a **binary sensor**, not a sensor — see "HVAC Status" below.)*
 #### Charging Data *(BEV/PHEV)*
 - Charging Status *(Unplugged / Charging (AC) / Charging (DC) / V2X Discharging / …)*
 - Charging Voltage
@@ -113,57 +110,64 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Charging Current Limit
 - Charging Power
 - Estimated Range After Charging
-- Charging Target SOC *(shown only on models where the iSmart app supports it)*
+- Target SOC *(read-only mirror of the Target SOC slider — shown only on models where the iSmart app supports it)*
 - Charging Duration
 - Remaining Charging Time
 - Added Electric Range
 - Power Usage Since Last Charge
 - Mileage Since Last Charge
 - Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value)*
-- Last Charge Ending Power *(kWh; corrected for models where the API reports an inaccurate value)*
+- Battery Heating Status *(if equipped)*
 ### BINARY SENSORS
  
 #### Doors
-- Driver Door
-- Passenger Door
-- Rear Left Door
-- Rear Right Door
+- Door Front Left / Door Front Right *(named "Driver"/"Passenger" logically, but labelled by physical side — automatically swapped for RHD vs LHD vehicles)*
+- Door Rear Left / Door Rear Right *(not present on 2-door models, e.g. MG Cyberster)*
 - Bonnet Status
 - Boot Status
 #### Windows
-- Driver Window
-- Passenger Window
-- Rear Left Window
-- Rear Right Window
+- Window Front Left / Window Front Right
+- Window Rear Left / Window Rear Right *(not present on convertibles with no rear glass, e.g. MG Cyberster)*
 - Sunroof Status *(if equipped)*
+#### Lights
+- Dipped Beam Status
+- Main Beam Status
+- Side Light Status
 #### Other
-- Lock Status
-- Charging Gun Status
+- Engine Status
+- HVAC Status *(the AC/climate running state — see states table for what "on" actually covers)*
+- Lock Status *(⚠️ reports on/off, not Locked/Unlocked — see Entity States Reference)*
+- Wheel Tyre Monitor Status *(a "problem" sensor — on means a TPMS/tyre fault is reported, not that everything is fine)*
+- Charging Gun State *(BEV/PHEV only)*
 ### EVENTS
  
-- **Command Error** — fired when a remote command (lock, AC, charge, etc.) fails or is rejected by the vehicle. Use this in automations to get notified when a command does not go through.
+- **Command Errors** — a single event entity with two possible event types:
+  - `command_error` — fired when a remote command (lock, AC, charge, etc.) fails or is rejected by the vehicle.
+  - `command_limit_reached` — fired specifically when the vehicle's remote-command allowance has been used up.
+  Use this in automations to get notified when a command does not go through.
 ### DEVICE TRACKER
 - Latitude
 - Longitude
 - Elevation (Altitude)
 - HDOP
 - Satellites
-- Heading
-- Raw Heading
+- Heading *(numeric, `raw_heading` attribute)*
+- Heading *(cardinal direction, e.g. N/NE/E/SE/S/SW/W/NW, `heading` attribute)*
 ### SWITCHES
 - Charging Start/Stop
 - Battery Heating *(if equipped)*
 - Front Defrost
 - Rear Window Defrost
-- Heated Seats *(if equipped)*
+- Heated Seat Front Left / Heated Seat Front Right *(if equipped; two independent switches, one per seat)*
 - Sunroof *(if equipped)*
-- Charging Port Lock
+- Charging Port Lock *(⚠️ "on" means locked — see Entity States Reference)*
 ### BUTTONS
-- Trigger Find My Car Alarm
+- Trigger Alarm
 - Update Vehicle Data
+- Open Boot *(momentary — releases the boot/tailgate latch; the SAIC API only supports remote opening, not closing, hence a button rather than a lock/cover)*
 ### LOCK
 - Lock entity for door lock/unlock
-- Boot/Tailgate lock entity
+  *(There is no separate lock entity for the boot/tailgate — use the "Open Boot" button instead, since the API only supports releasing the latch remotely, not locking it again.)*
 ### CLIMATE
 - AC Control Climate entity
   * Temperature
@@ -173,7 +177,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Target SOC *(shown only on models where the iSmart app supports it)*
 ### SELECT
 - Charging Current Limit
-- Heated Seats Level *(if equipped)*
+- Heated Seat Front Left Level / Heated Seat Front Right Level *(if equipped)*
 **Note: Actions (Services) can be accessed and activated from the Actions menu under Developer Tools.**
 ![image](https://github.com/user-attachments/assets/14be0d41-ae65-4738-8bc0-5b0f743c290f)
  
@@ -230,6 +234,88 @@ This means you can set a long polling interval (e.g. 30 minutes or more) for idl
 > **Multiple vehicles on one account:** The integration uses a single API session and a single message poll loop per SAIC account, regardless of how many vehicles are registered under it. This prevents session conflicts and duplicate API calls.
  
  
+## 📋 Entity States Reference
+ 
+This section lists every possible state for every status and control entity, so you know exactly what to expect when coding dashboards or automations. Home Assistant binary sensors always report the underlying state as **`on`/`off`** — never as descriptive text like "Locked"/"Unlocked" or "Open"/"Closed" — the description below tells you what `on` and `off` actually *mean* for each one. The friendly text ("Open", "Locked", etc.) is only shown in the Lovelace UI because of the entity's device class; the state itself, e.g. as read via `states('binary_sensor...')` in a template, is always `on` or `off`.
+ 
+### Binary sensors
+ 
+| Entity | Device class | `on` means | `off` means |
+|---|---|---|---|
+| Bonnet Status | door | Open | Closed |
+| Boot Status | door | Open | Closed |
+| Door Front Left / Front Right | door | Open | Closed |
+| Door Rear Left / Rear Right | door | Open | Closed |
+| Window Front Left / Front Right | window | Open | Closed |
+| Window Rear Left / Rear Right | window | Open | Closed |
+| Sunroof Status | window | Open | Closed |
+| Dipped Beam Status | light | Light on | Light off |
+| Main Beam Status | light | Light on | Light off |
+| Side Light Status | light | Light on | Light off |
+| Engine Status | power | Engine running | Engine not running |
+| HVAC Status | running | Climate control active (cooling, fan-only, defrost, or heat) | Climate control fully off |
+| **Lock Status** | lock | **Unlocked** | **Locked** |
+| Wheel Tyre Monitor Status | problem | Fault/problem reported (e.g. low pressure or TPMS fault) | No fault reported |
+| Charging Gun State | plug | Charging gun/cable plugged in | Unplugged |
+ 
+> **This is the entity from the issue report:** `binary_sensor` device class **`lock`** is the one HA device class where `on` does *not* mean "active/true" in the usual sense — by HA convention, `on` = unlocked (the "open" state) and `off` = locked. It is easy to assume `on` = Locked, but it's the opposite.
+ 
+### Lock entity
+ 
+| Entity | States |
+|---|---|
+| Lock | `locked` / `unlocked` (standard HA lock entity — reported as plain text, not on/off) |
+ 
+### Switches
+ 
+| Entity | `on` means | `off` means |
+|---|---|---|
+| Charging | Actively charging (AC or DC), or V2X discharging in progress | Not charging (includes "Scheduled Charging" status — the switch only reflects active current flow) |
+| Battery Heating | Battery heating active | Battery heating inactive |
+| Front Defrost | Front defrost running | Front defrost off |
+| Rear Window Defrost | Rear window heater on | Rear window heater off |
+| Heated Seat Front Left / Front Right | Seat heat level 1 or above (Low/Medium/High) | Seat heat level 0 (Off) |
+| Sunroof | Sunroof open | Sunroof closed |
+| **Charging Port Lock** | **Charging port locked** | **Charging port unlocked** |
+ 
+> Note that for **Charging Port Lock**, `on` = locked — the opposite convention to the `lock`-device-class binary sensor above. This is because it's a `switch` entity (where `on` simply reflects "the lock control is engaged"), not a `binary_sensor` with a `lock` device class.
+ 
+### Enumerated sensors (text states)
+ 
+| Entity | Possible states |
+|---|---|
+| Power Mode | `Off`, `Accessory`, `On`, `Start` |
+| Charging Status | `Unplugged`, `Charging (AC)`, `Charging Finished`, `Charging`, `Fault Charging`, `Connecting`, `Unrecognized Connection`, `Plugged In`, `Charging Stopped`, `Scheduled Charging`, `Charging (DC)`, `Super Offboard Charging`, `V2X Discharging` |
+| Battery Heating Status | `Off`, `On`, `Error` |
+| Front Left/Right Heated Seat Level | `Off`, `Low`, `Medium`, `High` |
+| Steering Wheel Heat | `Off`, `On` |
+| Charging Current Limit *(sensor)* | `0A (Ignore)`, `6A`, `8A`, `16A`, `Max` |
+| Target SOC *(sensor)* | `40`, `50`, `60`, `70`, `80`, `90`, `100` (%) |
+ 
+> The API reports two separate raw codes (`3` and `12`) that both map to the plain `Charging` text for the Charging Status sensor. If you need to tell them apart in an automation, use the numeric `bmsChrgSts` value via the debug log rather than the sensor state.
+ 
+### Select entities (settable, same options as their read-only sensor counterparts)
+ 
+| Entity | Options |
+|---|---|
+| Charging Current Limit | `0A (Ignore)`, `6A`, `8A`, `16A`, `Max` |
+| Heated Seat Front Left/Right Level | `Off`, `Low`, `Medium`, `High` |
+ 
+### Climate entity
+ 
+| Attribute | Possible values |
+|---|---|
+| HVAC mode | `Cool`, `Fan Only`, `Off` |
+| Fan mode | `Low`, `Medium`, `High` |
+ 
+### Event entity
+ 
+| Event type | Fired when | Event data |
+|---|---|---|
+| `command_error` | Any remote command fails or is rejected | `source` (which command), `error` (the error message) |
+| `command_limit_reached` | The vehicle's remote command allowance is used up | `source`, `message` |
+ 
+ 
 ## Vehicle Profiles
  
 The integration includes built-in profiles for specific MG/SAIC models that correct known inaccuracies in the API data:
@@ -237,14 +323,16 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
 | Series | Model | Notes |
 |---|---|---|
 | `EH32` | MG4 Electric | Temperature range and fan speed values confirmed |
-| `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index |
-| `AS33P` | MG HS PHEV (Super Hybrid 2025/2026) | BBattery capacity 24.7 kWh; Target SOC not supported by iSmart; electric range uses live SOC-tracking field |
+| `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index; model year override (API reports 2024, corrected to 2025) |
+| `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |
+| `IS31P` | MG S9 PHEV (2025) | Climate status/fan speed mappings confirmed by physical testing |
+| `AS33P` | MG HS PHEV (Super Hybrid 2025/2026) | Battery capacity 24.7 kWh; Target SOC and Charging Current Limit not supported by iSmart; electric range uses live SOC-tracking field; energy values corrected for ~3x API over-reporting |
  
 Models not listed above use safe default values and should work normally. If you notice incorrect sensor readings for your model, please open an issue with your vehicle's debug logs.
-
-
+ 
+ 
 ## 💡 Troubleshooting & FAQ
-
+ 
 * **"Invalid Credentials" or Connection Timeouts:** Ensure you are choosing the correct region (EU, China, Australia, Israel, Turkey, Rest of World) matching your mobile app setup.
 * **Entities showing as 'Unavailable':** The integration respects API rate limits to prevent account lockouts. If an entity is temporarily unavailable, wait for the next scheduled update or use the `button.update_vehicle_data` entity to force a refresh.
 * **My App keeps logging me out:** As noted above, ensure your Home Assistant integration uses a **Secondary Account**, not your primary mobile application credentials.
@@ -252,37 +340,35 @@ Models not listed above use safe default values and should work normally. If you
 * **Electric Range shows an unexpected value:** For some PHEV models the live electric range field is not populated by the API. The integration falls back to the estimated-range-after-full-charge figure from the charging management data.
 * **Two cars on the same account:** Fully supported. Both vehicles share a single API session so neither interferes with the other.
 * **Instant Power sensor shows a stale value after HA restart:** Home Assistant restores entity states from its database on startup. The value will update to `0 kW` on the first successful poll (usually within 30 seconds) if the car is not driving.
-
+* **"Lock Status" binary sensor shows on/off, not Locked/Unlocked:** This is expected HA behaviour for the `lock` device class — see the [Entity States Reference](#entity-states-reference) above for exactly what `on` and `off` mean for every status/control entity in this integration.
 ## How to enable logging
-
+ 
 * Add the following lines to `configuration.yaml` (or your sub `logger.yaml` file if you have broken down `configuraiton.yaml` into smaller files)
-  ```
+```
   logger:
   default: warning
   
   logs:
     custom_components.mg_saic: debug
-  ```
+```
 * Restart Home Assistant
 * Go to System -> Logs
 * Search for `mg_saic`
 * Click the 3 vertical dots
 * Choose `Show full logs`
-
 ## Contributing
-
+ 
 Contributions are welcome! If you have any suggestions or find any issues, please open an [issue](https://github.com/townsmcp/mg-saic-ha/issues) or a [pull request](https://github.com/townsmcp/mg-saic-ha/pulls).
-
+ 
 ## Credits
-
+ 
 This integration was made possible thanks to the [saic-ismart-client-ng](https://github.com/SAIC-iSmart-API/saic-python-client-ng) repository and its developers/contributors.
-
+ 
 Special thanks to ad-ha for creating the original integration and for the hard work put into building and maintaining it in its previous stages. This repository continues that work.
-
+ 
 ## License
-
+ 
 This project is licensed under the MIT License. See the LICENSE file for details.
-
 
 
 ## Disclaimer

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -128,12 +128,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         vehicles = await client.get_vehicle_info()
+        # A transient SAIC server error (e.g. HTTP 500 on /vehicle/list) can
+        # return None or an empty list rather than raising. Treat that as
+        # "not ready yet" and let HA retry with backoff, rather than a
+        # permanent setup failure that requires a manual reload once SAIC
+        # recovers. Guarding here also avoids "'NoneType' object is not
+        # iterable" when vehicles is None (reported by Johndowne, issue #203;
+        # root cause was a SAIC-side 500, not the integration).
+        if not vehicles:
+            raise ConfigEntryNotReady(
+                "SAIC API returned no vehicle list (likely a temporary "
+                "server-side error) — HA will retry automatically."
+            )
         if not any(v.vin == vin for v in vehicles):
             LOGGER.error("VIN %s not found in account vehicles", vin)
             return False
+    except ConfigEntryNotReady:
+        # Propagate so HA schedules an automatic retry.
+        raise
     except Exception as exc:
-        LOGGER.error("Failed to verify VIN %s: %s", vin, exc)
-        return False
+        # Any other error verifying the VIN (network blip, transient API
+        # failure) is also treated as "not ready" so HA retries rather than
+        # permanently failing setup.
+        raise ConfigEntryNotReady(
+            f"Could not verify VIN {vin} yet: {exc}"
+        ) from exc
 
     # Store a reference to the shared client under this entry's key so that
     # platform files (button.py, climate.py, …) can fetch it as normal via

--- a/custom_components/mg_saic/binary_sensor.py
+++ b/custom_components/mg_saic/binary_sensor.py
@@ -158,7 +158,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         ]
 
         # Rear doors — only present on 4-door vehicles (not e.g. Cyberster EC32).
-        # Derived from the DOOR bitmask in vehicleModelConfiguration by the coordinator.
+        # coordinator.has_rear_doors comes from the per-model VEHICLE_PROFILES
+        # entry in const.py, not the SAIC API's own DOOR bitmask — that field
+        # proved unreliable for the related WINDOW bitmask (issue #203), so
+        # both are now handled the same, explicit, way.
         if coordinator.has_rear_doors:
             binary_sensors.extend([
                 SAICMGBinarySensor(
@@ -182,7 +185,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
             ])
 
         # Rear windows — only present when the car has tracked rear windows.
-        # Convertibles (e.g. Cyberster) report WINDOW='0000' — no glass windows.
+        # coordinator.has_rear_windows comes from the per-model VEHICLE_PROFILES
+        # entry (const.py), not the SAIC API's WINDOW bitmask. That API field
+        # was found to be unreliable: MG4 and MGS5 (genuine 4-window cars)
+        # report WINDOW='0000' identically to the Cyberster's soft-top, which
+        # incorrectly suppressed their rear window entities (issue #203).
         if coordinator.has_rear_windows:
             binary_sensors.extend([
                 SAICMGBinarySensor(

--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -152,11 +152,15 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
                 # confirms (next coordinator refresh).
                 return self._attr_hvac_mode
             else:
-                # Unknown/unhandled status (e.g. 4=heat, 6=driving ventilation)
-                # — show as Off in HA; do not override local state.
-                if self._attr_hvac_mode in (HVACMode.OFF, None):
-                    return HVACMode.OFF
-                return self._attr_hvac_mode
+                # Unknown/unhandled status (e.g. 4=heat, 6=driving ventilation,
+                # or the car's own AC auto-shutoff timer firing). These mean
+                # the car is no longer actively cooling/fanning under our
+                # control, so trust the status and show Off — do not preserve
+                # stale local state here, or the climate entity gets stuck
+                # showing "Cool" indefinitely after the car shuts its AC off
+                # on its own (confirmed by eladrichi, issue #204, beta12).
+                self._attr_hvac_mode = HVACMode.OFF
+                return HVACMode.OFF
 
         # No API data available — fall back to last known local state
         return self._attr_hvac_mode if self._attr_hvac_mode is not None else HVACMode.OFF

--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -22,6 +22,13 @@ from .const import (
 )
 from .utils import create_device_info
 
+# Preset names used by the "mode_select" climate scheme (e.g. IS31P / MG S9 PHEV).
+# These are exposed as HA preset_modes for modes that don't map cleanly onto a
+# standard HVACMode — a fast strong-fan cool-down, and windscreen defrost.
+PRESET_NONE = "none"
+PRESET_MAX_COOL = "Max Cool"
+PRESET_DEFROST = "Defrost"
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the MG SAIC climate entity."""
@@ -40,7 +47,22 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
 
 class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
-    """Representation of the vehicle's climate control."""
+    """Representation of the vehicle's climate control.
+
+    Two control schemes are supported, selected per-model via the vehicle
+    profile (coordinator.climate_control_scheme):
+
+    * "fan_speed" (default): the classic behaviour. HA exposes a Low/Med/High
+      fan slider plus Off/Cool/Fan-only HVAC modes. The chosen fan value is
+      sent with each AC command. Used by MG4, MGS5, Cyberster, HS PHEV, and any
+      unprofiled model.
+
+    * "mode_select": for cars where the API's "fan_speed" byte is actually a
+      climate MODE selector, not a linear fan speed (confirmed on IS31P / MG
+      S9 PHEV — see const.py). HA instead exposes Off/Fan-only/Cool/Heat HVAC
+      modes plus "Max Cool" and "Defrost" presets, and no fan slider. Each maps
+      to a fixed mode integer; the car manages its own fan.
+    """
 
     def __init__(self, coordinator, client, entry, vin_info, vin):
         """Initialize the climate entity."""
@@ -50,31 +72,53 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         self._vin_info = vin_info
 
         self._series = vin_info.series
+        self._scheme = coordinator.climate_control_scheme
 
         self._attr_name = f"{vin_info.brandName} {vin_info.modelName} Climate"
         self._attr_unique_id = f"{entry.entry_id}_{vin}_climate"
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
-        self._attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE
-            | ClimateEntityFeature.FAN_MODE
-            | ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-        )
-        self._attr_hvac_modes = [
-            HVACMode.OFF,
-            HVACMode.COOL,
-            HVACMode.FAN_ONLY,
-        ]
-        self._attr_fan_modes = [FAN_LOW, FAN_MEDIUM, FAN_HIGH]
 
         self._device_info = create_device_info(coordinator, entry.entry_id)
 
-        # Initialize with default values
+        # Common initial state
         self._attr_min_temp = self.min_temp
         self._attr_max_temp = self.max_temp
         self._attr_target_temperature = 22.0
-        self._attr_fan_mode = FAN_MEDIUM
         self._attr_hvac_mode = HVACMode.OFF
+
+        if self._scheme == "mode_select":
+            # Mode-select cars: no fan slider, but add Heat + presets.
+            self._attr_supported_features = (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.PRESET_MODE
+                | ClimateEntityFeature.TURN_ON
+                | ClimateEntityFeature.TURN_OFF
+            )
+            self._attr_hvac_modes = [
+                HVACMode.OFF,
+                HVACMode.FAN_ONLY,
+                HVACMode.COOL,
+                HVACMode.HEAT,
+            ]
+            self._attr_preset_modes = [PRESET_NONE, PRESET_MAX_COOL, PRESET_DEFROST]
+            self._attr_preset_mode = PRESET_NONE
+            self._attr_fan_modes = None
+            self._attr_fan_mode = None
+        else:
+            # Classic fan-speed cars: Low/Med/High fan slider.
+            self._attr_supported_features = (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.FAN_MODE
+                | ClimateEntityFeature.TURN_ON
+                | ClimateEntityFeature.TURN_OFF
+            )
+            self._attr_hvac_modes = [
+                HVACMode.OFF,
+                HVACMode.COOL,
+                HVACMode.FAN_ONLY,
+            ]
+            self._attr_fan_modes = [FAN_LOW, FAN_MEDIUM, FAN_HIGH]
+            self._attr_fan_mode = FAN_MEDIUM
 
     @property
     def temperature_unit(self) -> str:
@@ -112,58 +156,105 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
                 return interior_temp
         return None
 
-    @property
-    def hvac_mode(self):
-        """Return the current HVAC mode.
-
-        Priority:
-        1. API-derived state (from remoteClimateStatus) when available — this
-           reflects what the car actually reports and keeps HA in sync after
-           the car responds to a command.
-        2. _attr_hvac_mode as fallback when API data is missing.
-
-        remoteClimateStatus values are model-specific — see VEHICLE_PROFILES
-        in const.py and coordinator.climate_status_cool / climate_status_fan_only.
-
-        MGS6: statuses 1/2/3 -> COOL (fan-speed dependent), 4/6 -> OFF
-        MG4:  status 3 -> COOL, status 2 -> FAN_ONLY
-        """
+    def _current_climate_status(self):
+        """Return the car's current remoteClimateStatus, or None if unavailable."""
         status = self.coordinator.data.get("status")
         if status and status.basicVehicleStatus:
-            climate_status = getattr(
-                status.basicVehicleStatus, "remoteClimateStatus", 0
-            )
-            # A non-zero status means the car has reported an active climate state.
-            # Trust it and update _attr_hvac_mode to stay in sync.
+            return getattr(status.basicVehicleStatus, "remoteClimateStatus", 0)
+        return None
+
+    @property
+    def hvac_mode(self):
+        """Return the current HVAC mode, derived from the car's reported status.
+
+        The car echoes its active climate mode back via remoteClimateStatus.
+        We map that to an HVAC mode using the per-model reverse maps in the
+        coordinator (climate_status_cool / _fan_only / _heat / _defrost).
+
+        When the car reports 0 (off) but we've just issued a command, we keep
+        the local state briefly so the UI doesn't flicker back to Off before
+        the car confirms. Any other unrecognised/inactive status resolves to
+        Off, so the entity never gets stuck showing an active mode after the
+        car shuts its climate off on its own (issue #204).
+        """
+        climate_status = self._current_climate_status()
+
+        if climate_status is not None:
+            if climate_status in self.coordinator.climate_status_heat:
+                self._attr_hvac_mode = HVACMode.HEAT
+                return HVACMode.HEAT
             if climate_status in self.coordinator.climate_status_cool:
                 self._attr_hvac_mode = HVACMode.COOL
                 return HVACMode.COOL
-            elif climate_status in self.coordinator.climate_status_fan_only:
+            if climate_status in self.coordinator.climate_status_defrost:
+                # Defrost is a preset layered on top of an active (cooling)
+                # system; report COOL as the base HVAC mode.
+                self._attr_hvac_mode = HVACMode.COOL
+                return HVACMode.COOL
+            if climate_status in self.coordinator.climate_status_fan_only:
                 self._attr_hvac_mode = HVACMode.FAN_ONLY
                 return HVACMode.FAN_ONLY
-            elif climate_status == 0:
-                # Car explicitly reports Off — but only trust this if our local
-                # state is also Off, or if we have no local state.  If we just
-                # sent a Cool command, the car takes a few seconds to respond;
-                # status=0 during that window should not override the command.
+            if climate_status == 0:
+                # Car reports Off — trust it unless we just sent a command and
+                # are waiting for the car to catch up.
                 if self._attr_hvac_mode in (HVACMode.OFF, None):
                     return HVACMode.OFF
-                # Local state says we sent a command — keep it until the car
-                # confirms (next coordinator refresh).
                 return self._attr_hvac_mode
-            else:
-                # Unknown/unhandled status (e.g. 4=heat, 6=driving ventilation,
-                # or the car's own AC auto-shutoff timer firing). These mean
-                # the car is no longer actively cooling/fanning under our
-                # control, so trust the status and show Off — do not preserve
-                # stale local state here, or the climate entity gets stuck
-                # showing "Cool" indefinitely after the car shuts its AC off
-                # on its own (confirmed by eladrichi, issue #204, beta12).
-                self._attr_hvac_mode = HVACMode.OFF
-                return HVACMode.OFF
+            # Unrecognised/inactive status → Off (do not preserve stale state).
+            self._attr_hvac_mode = HVACMode.OFF
+            return HVACMode.OFF
 
-        # No API data available — fall back to last known local state
+        # No API data — fall back to last known local state.
         return self._attr_hvac_mode if self._attr_hvac_mode is not None else HVACMode.OFF
+
+    @property
+    def preset_mode(self):
+        """Return the active preset (mode_select scheme only).
+
+        Derived from the car's reported status so it stays in sync: a status
+        matching the Max Cool value shows "Max Cool", the Defrost value shows
+        "Defrost", anything else shows "none".
+        """
+        if self._scheme != "mode_select":
+            return None
+
+        climate_status = self._current_climate_status()
+        if climate_status is not None:
+            if climate_status in self.coordinator.climate_status_defrost:
+                self._attr_preset_mode = PRESET_DEFROST
+                return PRESET_DEFROST
+            if climate_status == self.coordinator.climate_mode_max_cool:
+                self._attr_preset_mode = PRESET_MAX_COOL
+                return PRESET_MAX_COOL
+            self._attr_preset_mode = PRESET_NONE
+            return PRESET_NONE
+        return self._attr_preset_mode
+
+    def _temperature_idx(self):
+        """Return the API temperature index for the current target temp."""
+        temp_clamped = int(
+            max(self.min_temp, min(self.max_temp, round(self._attr_target_temperature)))
+        )
+        return self.coordinator.get_ac_temperature_idx(temp_clamped)
+
+    async def _send_climate_command(self, mode_value: int, hvac_mode, preset=PRESET_NONE):
+        """Send a climate command using a raw mode/fan integer, update state,
+        and schedule the post-action refresh. Shared by both schemes."""
+        await self._client.start_climate(
+            self._vin,
+            temperature_idx=self._temperature_idx(),
+            fan_speed=mode_value,
+            ac_on=True,
+        )
+        self._attr_hvac_mode = hvac_mode
+        if self._scheme == "mode_select":
+            self._attr_preset_mode = preset
+        self.async_write_ha_state()
+        await self.coordinator.schedule_action_refresh(
+            self._vin,
+            self.coordinator.after_action_delay,
+            self.coordinator.ac_long_interval,
+        )
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set the HVAC mode."""
@@ -171,51 +262,15 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
             if hvac_mode == HVACMode.OFF:
                 await self._client.stop_ac(self._vin)
                 self._attr_hvac_mode = HVACMode.OFF
+                if self._scheme == "mode_select":
+                    self._attr_preset_mode = PRESET_NONE
                 self.async_write_ha_state()
                 return
 
-            # Common parameters for climate modes
-            min_temp = self.min_temp
-            max_temp = self.max_temp
-            temp_clamped = int(
-                max(min_temp, min(max_temp, round(self._attr_target_temperature)))
-            )
-
-            # Get temperature index from coordinator
-            temperature_idx = self.coordinator.get_ac_temperature_idx(temp_clamped)
-
-            if hvac_mode == HVACMode.COOL:
-                # Cooling mode
-                await self._client.start_climate(
-                    self._vin,
-                    temperature_idx=temperature_idx,
-                    fan_speed=self._fan_speed_to_int(),
-                    ac_on=True,
-                )
-
-            elif hvac_mode == HVACMode.FAN_ONLY:
-                # Fan-only mode
-                await self._client.start_ac(
-                    vin=self._vin,
-                    temperature_idx=temperature_idx,
-                )
-
+            if self._scheme == "mode_select":
+                await self._set_hvac_mode_select(hvac_mode)
             else:
-                LOGGER.warning("Unsupported HVAC mode: %s", hvac_mode)
-                return
-
-            self._attr_hvac_mode = hvac_mode
-            self.async_write_ha_state()
-
-            # Schedule data refresh
-            immediate_interval = self.coordinator.after_action_delay
-            long_interval = self.coordinator.ac_long_interval
-
-            await self.coordinator.schedule_action_refresh(
-                self._vin,
-                immediate_interval,
-                long_interval,
-            )
+                await self._set_hvac_fan_speed(hvac_mode)
 
         except CommandsLimitReachedException:
             await self.coordinator.notify_command_limit_reached(self._vin)
@@ -223,35 +278,97 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
             LOGGER.error("Error setting HVAC mode for VIN %s: %s", self._vin, e)
             self.coordinator.record_command_error("Error setting HVAC mode", e)
 
-    async def async_turn_on(self):
-        """Turn the climate entity on."""
-        immediate_interval = self.coordinator.after_action_delay
-        long_interval = self.coordinator.ac_long_interval
+    async def _set_hvac_mode_select(self, hvac_mode):
+        """Handle HVAC mode changes for the mode_select scheme."""
+        c = self.coordinator
+        if hvac_mode == HVACMode.COOL:
+            await self._send_climate_command(c.climate_mode_cool, HVACMode.COOL)
+        elif hvac_mode == HVACMode.HEAT:
+            await self._send_climate_command(c.climate_mode_heat, HVACMode.HEAT)
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            await self._send_climate_command(c.climate_mode_fan_only, HVACMode.FAN_ONLY)
+        else:
+            LOGGER.warning("Unsupported HVAC mode for mode_select: %s", hvac_mode)
 
+    async def _set_hvac_fan_speed(self, hvac_mode):
+        """Handle HVAC mode changes for the classic fan_speed scheme."""
+        if hvac_mode == HVACMode.COOL:
+            await self._client.start_climate(
+                self._vin,
+                temperature_idx=self._temperature_idx(),
+                fan_speed=self._fan_speed_to_int(),
+                ac_on=True,
+            )
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            await self._client.start_ac(
+                vin=self._vin,
+                temperature_idx=self._temperature_idx(),
+            )
+        else:
+            LOGGER.warning("Unsupported HVAC mode: %s", hvac_mode)
+            return
+
+        self._attr_hvac_mode = hvac_mode
+        self.async_write_ha_state()
+        await self.coordinator.schedule_action_refresh(
+            self._vin,
+            self.coordinator.after_action_delay,
+            self.coordinator.ac_long_interval,
+        )
+
+    async def async_set_preset_mode(self, preset_mode):
+        """Set a preset mode (mode_select scheme only): Max Cool or Defrost."""
+        if self._scheme != "mode_select":
+            LOGGER.warning("Preset modes are not supported for this vehicle.")
+            return
+
+        try:
+            c = self.coordinator
+            if preset_mode == PRESET_MAX_COOL:
+                await self._send_climate_command(
+                    c.climate_mode_max_cool, HVACMode.COOL, preset=PRESET_MAX_COOL
+                )
+            elif preset_mode == PRESET_DEFROST:
+                await self._send_climate_command(
+                    c.climate_mode_defrost, HVACMode.COOL, preset=PRESET_DEFROST
+                )
+            elif preset_mode == PRESET_NONE:
+                # Returning to "none" means plain cool (auto fan).
+                await self._send_climate_command(
+                    c.climate_mode_cool, HVACMode.COOL, preset=PRESET_NONE
+                )
+            else:
+                LOGGER.warning("Unsupported preset mode: %s", preset_mode)
+
+        except CommandsLimitReachedException:
+            await self.coordinator.notify_command_limit_reached(self._vin)
+        except Exception as e:
+            LOGGER.error("Error setting preset mode for VIN %s: %s", self._vin, e)
+            self.coordinator.record_command_error("Error setting preset mode", e)
+
+    async def async_turn_on(self):
+        """Turn the climate entity on (defaults to Cool)."""
         await self.async_set_hvac_mode(HVACMode.COOL)
         await self.coordinator.schedule_action_refresh(
             self._vin,
-            immediate_interval,
-            long_interval,
+            self.coordinator.after_action_delay,
+            self.coordinator.ac_long_interval,
         )
 
     async def async_turn_off(self):
         """Turn the climate entity off."""
-        immediate_interval = self.coordinator.after_action_delay
-        long_interval = self.coordinator.ac_long_interval
-
         await self.async_set_hvac_mode(HVACMode.OFF)
         await self.coordinator.schedule_action_refresh(
             self._vin,
-            immediate_interval,
-            long_interval,
+            self.coordinator.after_action_delay,
+            self.coordinator.ac_long_interval,
         )
 
     async def async_set_temperature(self, **kwargs):
         """Update the target temperature in local state only.
 
         Temperature is stored locally and applied the next time the user
-        explicitly changes HVAC mode (which sends the actual command).
+        explicitly changes HVAC/preset mode (which sends the actual command).
         Changing temperature alone does NOT send a command — this preserves
         the 3-command-per-day limit for intentional AC actions only.
         """
@@ -259,9 +376,7 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         if temperature is None:
             return
 
-        min_temp = self.min_temp
-        max_temp = self.max_temp
-        temp_clamped = int(max(min_temp, min(max_temp, round(temperature))))
+        temp_clamped = int(max(self.min_temp, min(self.max_temp, round(temperature))))
 
         if temp_clamped != self._attr_target_temperature:
             LOGGER.debug(
@@ -273,18 +388,24 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
 
     @property
     def fan_mode(self):
-        """Return the current fan mode."""
+        """Return the current fan mode (fan_speed scheme only)."""
+        if self._scheme == "mode_select":
+            return None
         return self._attr_fan_mode
 
     async def async_set_fan_mode(self, fan_mode):
-        """Update the fan mode in local state only.
+        """Update the fan mode in local state only (fan_speed scheme only).
 
         Fan mode is stored locally and applied the next time the user
         explicitly changes HVAC mode (which sends the actual command).
         Changing fan mode alone does NOT send a command — this preserves
         the 3-command-per-day limit for intentional AC actions only.
         """
-        if fan_mode in self._attr_fan_modes:
+        if self._scheme == "mode_select":
+            LOGGER.warning("Fan modes are not supported for this vehicle.")
+            return
+
+        if fan_mode in (self._attr_fan_modes or []):
             self._attr_fan_mode = fan_mode
             LOGGER.debug(
                 "Fan mode updated to %s (will apply on next AC command)", fan_mode
@@ -302,10 +423,10 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         )
 
     def _fan_speed_to_int(self):
-        """Convert fan mode to integer value expected by the API.
+        """Convert fan mode to integer value expected by the API (fan_speed scheme).
 
         Fan speed values are model-specific — values 4 and 5 trigger heating
-        and defrost on the MGS6, so per-model values are stored in the
+        and defrost on some models, so per-model values are stored in the
         coordinator's fan_speed_low/medium/high from VEHICLE_PROFILES.
         """
         return {

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -226,15 +226,19 @@ VEHICLE_PROFILES = {
         #   5 → AC on, defog/windscreen vents        ✗ (original beta7 tests)
         #
         # Fan speed mappings (SL='1_2_5', but 3 also accepted):
-        #   fan_speed_low=2    → remoteClimateStatus=2 (AC on, main vents)
-        #   fan_speed_medium=4 → UNCONFIRMED. beta12 had this duplicated with
-        #     fan_speed_low (both =2), which made HA's Low and Medium fan
-        #     settings send an identical command (issue #204, beta12 feedback).
-        #     4 has never been tested — it's the only untested value between
-        #     the two confirmed-safe ones (2 and 3) and the avoided ones
-        #     (1=fan only, 5=defog vents). Needs confirmation from eladrichi
-        #     before being trusted; if 4 turns out to behave like 1 or 5, this
-        #     should fall back to matching fan_speed_high (3) instead.
+        #   fan_speed_low=2    → remoteClimateStatus=2 (AC on, main vents, lower fan)
+        #   fan_speed_medium=3 → remoteClimateStatus=3 (AC on, main vents, higher fan)
+        #     Duplicates fan_speed_high. beta1 tried 4 here, but eladrichi
+        #     confirmed (issue #204, 2026-07-01) that 4 is NOT a third cooling
+        #     tier — it triggers heat mode (max temp, leg vents), matching the
+        #     "4 = heating/defrost" pattern already seen on MG4/MGS6. Combined
+        #     with the car's own supported fan-speed list (SL='1_2_5'), the
+        #     full command map is almost certainly: 1=fan only, 2=cool low,
+        #     3=cool high, 4=heat, 5=defog — i.e. only two genuine cooling fan
+        #     levels exist via this API, so Medium and High cannot be made
+        #     distinct without further discovery. Duplicating High (3) here
+        #     rather than Low (2) at least keeps Low distinguishable, which
+        #     was the original beta12 complaint.
         #   fan_speed_high=3   → remoteClimateStatus=3 (AC on, main vents, more powerful)
         #
         # Temperature index confirmed correct (temp_idx_inverted=False):
@@ -246,7 +250,7 @@ VEHICLE_PROFILES = {
         "climate_status_cool": {2, 3},
         "climate_status_fan_only": {1},
         "fan_speed_low": 2,
-        "fan_speed_medium": 4,
+        "fan_speed_medium": 3,
         "fan_speed_high": 3,
         "temp_idx_inverted": False,
         "supports_target_soc": True,

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -156,18 +156,6 @@ VEHICLE_PROFILES = {
         "max_temp": 28,
         "temp_offset": 2,
         "battery_capacity_kwh": 74.3,
-        # On MGS6, remoteClimateStatus reflects fan speed during cooling:
-        #   1 = cooling low fan (assumed, not yet tested)
-        #   2 = cooling medium fan (confirmed)
-        #   3 = cooling high fan (confirmed)
-        #   4 = heating/defrost, 6 = driving ventilation (both shown as OFF)
-        "climate_status_cool": {1, 2, 3},
-        "climate_status_fan_only": set(),  # MGS6 does not expose fan-only via status
-        # On MGS6, fan speeds 4 and 5 trigger heating and defrost respectively.
-        # Cooling fan speeds are 1 (low), 2 (medium), 3 (high).
-        "fan_speed_low": 1,
-        "fan_speed_medium": 2,
-        "fan_speed_high": 3,
         # Temperature index direction: True = inverted (low temp -> high idx)
         # Confirmed: idx=14 at 16°C correctly cooled the MGS6.
         "temp_idx_inverted": True,
@@ -177,6 +165,31 @@ VEHICLE_PROFILES = {
         # The MGS6 launched globally to dealerships in November 2025 — there is
         # no 2024 model year variant.  Override to the correct value.
         "model_year_override": "2025",
+        # --- mode_select climate scheme (PROVISIONAL) ---
+        # Switched to mode_select alongside IS31P. Only the cool value (2) is
+        # confirmed for the MGS6 so far: a 2026-07-01 mitmproxy capture showed
+        # AC-on sends a command that returns remoteClimateStatus=2, respects the
+        # HA target temperature, and returns cleanly to 0 on shutdown — matching
+        # the S9's "2 = auto cool" behaviour.
+        #
+        # The remaining values (heat/max_cool/defrost/fan_only) are INHERITED
+        # from the IS31P defaults below and are NOT yet confirmed for this car.
+        # They will be verified and corrected during the full A–M test suite
+        # (planned Friday). NOTE: the MGS6's own iSmart app DOES show a fan
+        # slider (unlike the S9), so it is possible this model genuinely
+        # supports linear fan control and should revert to the "fan_speed"
+        # scheme after testing — this mode_select assignment is deliberately
+        # provisional pending those results.
+        "climate_control_scheme": "mode_select",
+        "climate_mode_cool": 2,        # CONFIRMED (mitmproxy, 2026-07-01)
+        "climate_mode_fan_only": 1,    # provisional — verify Friday
+        "climate_mode_heat": 4,        # provisional — verify Friday
+        "climate_mode_max_cool": 3,    # provisional — verify Friday
+        "climate_mode_defrost": 5,     # provisional — verify Friday
+        "climate_status_cool": {2, 3},     # provisional
+        "climate_status_fan_only": {1},    # provisional
+        "climate_status_heat": {4},        # provisional
+        "climate_status_defrost": {5},     # provisional
     },
     "EC32": {  # MG Cyberster (2-door BEV roadster/convertible)
         # The Cyberster has no rear doors or rear windows — see the
@@ -219,27 +232,26 @@ VEHICLE_PROFILES = {
         # Series string from API: 'IS31P L'
         # Confirmed by eladrichi (issue #204), modelYear='2025', PHEV.
         #
-        # remoteClimateStatus mappings confirmed by physical testing:
-        #   1 → fan only, no AC compressor (original beta7 tests)
-        #   2 → AC on, main vents, lower fan speed  ✓ (Test 1, beta11)
-        #   3 → AC on, main vents, higher fan speed ✓ (Test 2/3, beta11)
-        #   5 → AC on, defog/windscreen vents        ✗ (original beta7 tests)
+        # IMPORTANT — this model uses the "mode_select" climate scheme, NOT a
+        # fan speed slider. Extensive testing by eladrichi (issue #204) plus
+        # independent analysis established that the API's "fan_speed" byte is
+        # actually a climate MODE selector: the car echoes it back verbatim as
+        # remoteClimateStatus, and each value selects a fixed operating mode,
+        # NOT a linear fan intensity. The car manages its own fan speed.
         #
-        # Fan speed mappings (SL='1_2_5', but 3 also accepted):
-        #   fan_speed_low=2    → remoteClimateStatus=2 (AC on, main vents, lower fan)
-        #   fan_speed_medium=3 → remoteClimateStatus=3 (AC on, main vents, higher fan)
-        #     Duplicates fan_speed_high. beta1 tried 4 here, but eladrichi
-        #     confirmed (issue #204, 2026-07-01) that 4 is NOT a third cooling
-        #     tier — it triggers heat mode (max temp, leg vents), matching the
-        #     "4 = heating/defrost" pattern already seen on MG4/MGS6. Combined
-        #     with the car's own supported fan-speed list (SL='1_2_5'), the
-        #     full command map is almost certainly: 1=fan only, 2=cool low,
-        #     3=cool high, 4=heat, 5=defog — i.e. only two genuine cooling fan
-        #     levels exist via this API, so Medium and High cannot be made
-        #     distinct without further discovery. Duplicating High (3) here
-        #     rather than Low (2) at least keeps Low distinguishable, which
-        #     was the original beta12 complaint.
-        #   fan_speed_high=3   → remoteClimateStatus=3 (AC on, main vents, more powerful)
+        # Confirmed value → behaviour map (value sent == remoteClimateStatus):
+        #   1 → fan only, AC compressor off
+        #   2 → AC cooling, AUTO fan, follows the HA target temperature, main
+        #       vents. This is the sensible default "cool" mode.
+        #   3 → AC cooling, fixed strong fan (~6/11), main vents, temp forced
+        #       low. Exposed as the "Max Cool" preset (fast cool-down / boost).
+        #   4 → heat: max temp, ~3/11 fan, leg vents. Exposed as HVAC "heat".
+        #   5 → defrost: upper/windscreen vents. Exposed as "Defrost" preset.
+        #
+        # HA presents this as:
+        #   hvac_modes:   off / fan_only / cool / heat
+        #   preset_modes: Max Cool / Defrost
+        #   (no fan-speed slider — it would misrepresent a mode selector)
         #
         # Temperature index confirmed correct (temp_idx_inverted=False):
         #   16°C → index 2, 22°C → index 8 (matches temp_offset=2 formula).
@@ -247,15 +259,24 @@ VEHICLE_PROFILES = {
         "max_temp": 28,
         "temp_offset": 2,
         "battery_capacity_kwh": None,
-        "climate_status_cool": {2, 3},
-        "climate_status_fan_only": {1},
-        "fan_speed_low": 2,
-        "fan_speed_medium": 3,
-        "fan_speed_high": 3,
         "temp_idx_inverted": False,
         "supports_target_soc": True,
         "reliable_fuel_range_elec": True,
         "supports_charging_current_limit": True,
+        # --- mode_select climate scheme ---
+        "climate_control_scheme": "mode_select",
+        "climate_mode_fan_only": 1,
+        "climate_mode_cool": 2,
+        "climate_mode_heat": 4,
+        "climate_mode_max_cool": 3,
+        "climate_mode_defrost": 5,
+        # Reverse maps: remoteClimateStatus value → HA state.
+        #   cool covers both the auto-cool (2) and Max-Cool boost (3) values,
+        #   so a running boost still shows as "cool" in HA.
+        "climate_status_cool": {2, 3},
+        "climate_status_fan_only": {1},
+        "climate_status_heat": {4},
+        "climate_status_defrost": {5},
     },
     "AS33P": {  # MG HS PHEV (2025/2026 Super Hybrid)
         # Series string from API: 'AS33P S'
@@ -329,6 +350,12 @@ DEFAULT_VEHICLE_PROFILE = {
     # the API's own DOOR/WINDOW vehicleModelConfiguration bitmask.
     "has_rear_doors": True,
     "has_rear_windows": True,
+    # Default climate control scheme: "fan_speed" — HA shows a Low/Med/High
+    # fan slider. Only override to "mode_select" for models where the API's
+    # fan_speed byte is really a mode selector (see IS31P). The mode_select
+    # value keys (climate_mode_*, climate_status_heat/defrost) are only read
+    # when the scheme is "mode_select", so they don't need to appear here.
+    "climate_control_scheme": "fan_speed",
 }
 
 # Base update intervals

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -179,9 +179,12 @@ VEHICLE_PROFILES = {
         "model_year_override": "2025",
     },
     "EC32": {  # MG Cyberster (2-door BEV roadster/convertible)
-        # The Cyberster has no rear doors or rear windows — these are suppressed
-        # automatically via the DOOR/WINDOW bitmask in vehicleModelConfiguration
-        # (DOOR='1100', WINDOW='0000'), so no profile flag is needed for that.
+        # The Cyberster has no rear doors or rear windows — see the
+        # has_rear_doors/has_rear_windows override at the bottom of this
+        # profile. Originally this was inferred automatically from the
+        # DOOR/WINDOW bitmask in vehicleModelConfiguration, but that field
+        # proved unreliable across other models (issue #203) so it's now an
+        # explicit profile flag instead.
         #
         # fuelRangeElec: the log shows -128 (sentinel value) when parked, same
         # pattern as the HS PHEV.  Fall back to bmsEstdElecRng instead.
@@ -202,6 +205,15 @@ VEHICLE_PROFILES = {
         "supports_target_soc": True,
         "reliable_fuel_range_elec": False,
         "supports_charging_current_limit": True,
+        # The Cyberster is a 2-door convertible with no rear doors or rear
+        # glass windows. Previously this was inferred from the API's own
+        # DOOR/WINDOW vehicleModelConfiguration bitmask, but that data proved
+        # unreliable: MG4 and MGS5 (genuine 4-door/4-window cars) report
+        # WINDOW='0000' identically to the Cyberster, which incorrectly
+        # suppressed their rear window entities (issue #203). This is now an
+        # explicit per-model override instead of trusting the API field.
+        "has_rear_doors": False,
+        "has_rear_windows": False,
     },
     "IS31P": {  # MG S9 PHEV (2025)
         # Series string from API: 'IS31P L'
@@ -269,7 +281,7 @@ VEHICLE_PROFILES = {
         # Suppress both the status sensor and the select control for this model.
         "supports_charging_current_limit": False,
         # The API returns fuelRangeElec=-128 (sentinel) for this model when the car
-        # is parked — the live electric range field is not populated. Fall back to
+        # is parked — the live electric range field is not populated.  Fall back to
         # bmsEstdElecRng (estimated range after full charge) from chrgMgmtData.
         "reliable_fuel_range_elec": False,
         # Correction factor for energy-based fields that the API reports inflated
@@ -306,6 +318,13 @@ DEFAULT_VEHICLE_PROFILE = {
     "charging_capacity_correction": None,
     # Default: no model year override (API value is correct for most models).
     "model_year_override": None,
+    # Default: assume the car has rear doors and rear windows (true for the
+    # vast majority of models — 4-door cars). Only override to False for
+    # models confirmed to genuinely lack them, e.g. EC32 (Cyberster).
+    # See issue #203 for why this is a profile flag rather than read from
+    # the API's own DOOR/WINDOW vehicleModelConfiguration bitmask.
+    "has_rear_doors": True,
+    "has_rear_windows": True,
 }
 
 # Base update intervals

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -214,9 +214,16 @@ VEHICLE_PROFILES = {
         #   5 → AC on, defog/windscreen vents        ✗ (original beta7 tests)
         #
         # Fan speed mappings (SL='1_2_5', but 3 also accepted):
-        #   fan_speed_low=2  → remoteClimateStatus=2 (AC on, main vents)
-        #   fan_speed_high=3 → remoteClimateStatus=3 (AC on, main vents, more powerful)
-        #   Speed 1 avoided (fan only), speed 5 avoided (defog vents).
+        #   fan_speed_low=2    → remoteClimateStatus=2 (AC on, main vents)
+        #   fan_speed_medium=4 → UNCONFIRMED. beta12 had this duplicated with
+        #     fan_speed_low (both =2), which made HA's Low and Medium fan
+        #     settings send an identical command (issue #204, beta12 feedback).
+        #     4 has never been tested — it's the only untested value between
+        #     the two confirmed-safe ones (2 and 3) and the avoided ones
+        #     (1=fan only, 5=defog vents). Needs confirmation from eladrichi
+        #     before being trusted; if 4 turns out to behave like 1 or 5, this
+        #     should fall back to matching fan_speed_high (3) instead.
+        #   fan_speed_high=3   → remoteClimateStatus=3 (AC on, main vents, more powerful)
         #
         # Temperature index confirmed correct (temp_idx_inverted=False):
         #   16°C → index 2, 22°C → index 8 (matches temp_offset=2 formula).
@@ -227,7 +234,7 @@ VEHICLE_PROFILES = {
         "climate_status_cool": {2, 3},
         "climate_status_fan_only": {1},
         "fan_speed_low": 2,
-        "fan_speed_medium": 2,
+        "fan_speed_medium": 4,
         "fan_speed_high": 3,
         "temp_idx_inverted": False,
         "supports_target_soc": True,
@@ -262,7 +269,7 @@ VEHICLE_PROFILES = {
         # Suppress both the status sensor and the select control for this model.
         "supports_charging_current_limit": False,
         # The API returns fuelRangeElec=-128 (sentinel) for this model when the car
-        # is parked — the live electric range field is not populated.  Fall back to
+        # is parked — the live electric range field is not populated. Fall back to
         # bmsEstdElecRng (estimated range after full charge) from chrgMgmtData.
         "reliable_fuel_range_elec": False,
         # Correction factor for energy-based fields that the API reports inflated

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -117,6 +117,31 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         self.fan_speed_medium: int = 3
         self.fan_speed_high: int = 5
         self.temp_idx_inverted: bool = False
+        # Climate control scheme (see VEHICLE_PROFILES in const.py):
+        #   "fan_speed"   — the classic model: HA exposes a Low/Med/High fan
+        #                   slider, and the selected fan value is sent with each
+        #                   AC command. This is the default for all models.
+        #   "mode_select" — for cars (e.g. IS31P / MG S9 PHEV) where the API's
+        #                   "fan_speed" byte is really a climate MODE selector,
+        #                   not a linear fan speed. HA instead exposes hvac_mode
+        #                   (off/fan_only/cool/heat) + preset_mode (Max Cool /
+        #                   Defrost), each mapping to a fixed mode value. No fan
+        #                   slider is shown for these models.
+        self.climate_control_scheme: str = "fan_speed"
+        # mode_select value map (only used when scheme == "mode_select").
+        # Maps each logical climate action to the integer sent via the API's
+        # fan_speed parameter. Defaults are the IS31P-confirmed values but are
+        # always overridden per-profile when the scheme is mode_select.
+        self.climate_mode_fan_only: int = 1   # HVACMode.FAN_ONLY
+        self.climate_mode_cool: int = 2       # HVACMode.COOL (auto fan, follows temp)
+        self.climate_mode_heat: int = 4       # HVACMode.HEAT
+        self.climate_mode_max_cool: int = 3   # preset "Max Cool" (fixed strong fan)
+        self.climate_mode_defrost: int = 5    # preset "Defrost"
+        # Reverse map: remoteClimateStatus values that mean "heating".
+        # (cool/fan_only reverse maps already exist as climate_status_cool /
+        # climate_status_fan_only above.)
+        self.climate_status_heat: set = set()
+        self.climate_status_defrost: set = set()
         # Per-model feature flags — set from VEHICLE_PROFILES on first data fetch.
         self.supports_target_soc: bool = True
         self.reliable_fuel_range_elec: bool = True
@@ -607,6 +632,15 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.fan_speed_medium = profile.get("fan_speed_medium", 3)
             self.fan_speed_high = profile.get("fan_speed_high", 5)
             self.temp_idx_inverted = profile.get("temp_idx_inverted", False)
+            # Climate control scheme + mode_select value map (see const.py).
+            self.climate_control_scheme = profile.get("climate_control_scheme", "fan_speed")
+            self.climate_mode_fan_only = profile.get("climate_mode_fan_only", 1)
+            self.climate_mode_cool = profile.get("climate_mode_cool", 2)
+            self.climate_mode_heat = profile.get("climate_mode_heat", 4)
+            self.climate_mode_max_cool = profile.get("climate_mode_max_cool", 3)
+            self.climate_mode_defrost = profile.get("climate_mode_defrost", 5)
+            self.climate_status_heat = profile.get("climate_status_heat", set())
+            self.climate_status_defrost = profile.get("climate_status_defrost", set())
             self.supports_target_soc = profile.get("supports_target_soc", True)
             self.reliable_fuel_range_elec = profile.get("reliable_fuel_range_elec", True)
             self.charging_capacity_correction = profile.get("charging_capacity_correction", None)
@@ -625,6 +659,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 "Temp index inverted: %s, "
                 "Fan speeds: low=%d mid=%d high=%d, "
                 "Cool status codes: %s, "
+                "Climate scheme: %s, "
                 "Rear doors: %s, Rear windows: %s",
                 self.vehicle_series,
                 matched_series_key or "default/unprofiled",
@@ -636,6 +671,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 self.fan_speed_medium,
                 self.fan_speed_high,
                 self.climate_status_cool,
+                self.climate_control_scheme,
                 self.has_rear_doors,
                 self.has_rear_windows,
             )

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -242,11 +242,15 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             config_entry.data.get("has_steering_wheel_heat", False),
         )
 
-        # Derived from vehicleModelConfiguration on first data fetch.
-        # The DOOR bitmask (positions: FL, FR, RL, RR) tells us whether the car
-        # has rear doors. The WINDOW bitmask uses the same layout.
-        # Default True so that pre-existing installations without a data fetch
-        # yet don't suddenly lose entities; corrected on first _update_state.
+        # Whether the car has rear doors/windows — driven by the per-model
+        # VEHICLE_PROFILES entry (see const.py), not the SAIC API's own
+        # DOOR/WINDOW vehicleModelConfiguration bitmask. That API data proved
+        # unreliable: it reported WINDOW='0000' for 4-door/4-window cars
+        # (MG4, MGS5) exactly the same way it does for the 2-door Cyberster,
+        # which suppressed valid rear window entities for those cars.
+        # See issue #203. Default True until the profile is loaded on first
+        # data fetch, so pre-existing installations don't lose entities
+        # before _update_state runs.
         self.has_rear_doors = True
         self.has_rear_windows = True
 
@@ -608,13 +612,20 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.charging_capacity_correction = profile.get("charging_capacity_correction", None)
             self.supports_charging_current_limit = profile.get("supports_charging_current_limit", True)
             self.model_year_override = profile.get("model_year_override", None)
+            # Rear door/window presence — from the vehicle profile, not the
+            # API's DOOR/WINDOW bitmask (see issue #203; that bitmask data is
+            # unreliable for WINDOW across models). Defaults to True (has
+            # rear doors/windows) for any unprofiled or 4-door/4-window car.
+            self.has_rear_doors = profile.get("has_rear_doors", True)
+            self.has_rear_windows = profile.get("has_rear_windows", True)
 
             LOGGER.debug(
                 "Vehicle series detected: %s (profile: %s). "
                 "Temperature range: %d-%d°C, Offset: %d, "
                 "Temp index inverted: %s, "
                 "Fan speeds: low=%d mid=%d high=%d, "
-                "Cool status codes: %s",
+                "Cool status codes: %s, "
+                "Rear doors: %s, Rear windows: %s",
                 self.vehicle_series,
                 matched_series_key or "default/unprofiled",
                 self.min_temp,
@@ -625,6 +636,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 self.fan_speed_medium,
                 self.fan_speed_high,
                 self.climate_status_cool,
+                self.has_rear_doors,
+                self.has_rear_windows,
             )
             if self.known_battery_capacity_kwh is not None:
                 LOGGER.debug(
@@ -634,42 +647,15 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                     self.known_battery_capacity_kwh,
                 )
 
-            # Parse vehicleModelConfiguration bitmasks to determine which
-            # physical features the car actually has.
-            #
-            # DOOR: 4-char bitmask "FLFRRLRR" — '1' = door present.
-            #   e.g. "1100" → front doors only (no rear doors) = Cyberster.
-            #   e.g. "1111" → all four doors.
-            # WINDOW: same 4-position layout as DOOR.
-            #   e.g. "0000" → no tracked windows (Cyberster soft-top).
-            #   e.g. "1111" → all windows.
-            #
-            # These are read from the API's own vehicle config, so no profile
-            # entry is needed — any car reports its own physical spec.
-            door_value = None
-            window_value = None
-            for config_item in vin_info.vehicleModelConfiguration:
-                if config_item.itemCode == "DOOR":
-                    door_value = config_item.itemValue
-                elif config_item.itemCode == "WINDOW":
-                    window_value = config_item.itemValue
+            # NOTE: rear door/window presence is no longer derived from the
+            # API's DOOR/WINDOW vehicleModelConfiguration bitmask. That data
+            # proved unreliable — MG4 and MGS5 (both 4-door, 4-window cars)
+            # report WINDOW='0000' identically to the 2-door Cyberster, which
+            # incorrectly suppressed valid rear window entities for them
+            # (issue #203). has_rear_doors/has_rear_windows are now set from
+            # the VEHICLE_PROFILES entry above instead (see EC32 for the
+            # Cyberster override).
 
-            # Positions 2 and 3 (0-indexed) = rear-left and rear-right.
-            # If the bitmask is shorter than expected, default to True (safe).
-            if door_value is not None and len(door_value) >= 4:
-                self.has_rear_doors = door_value[2] == "1" or door_value[3] == "1"
-            if window_value is not None and len(window_value) >= 4:
-                self.has_rear_windows = window_value[2] == "1" or window_value[3] == "1"
-
-            LOGGER.debug(
-                "Vehicle body config for series %s: DOOR=%s → has_rear_doors=%s, "
-                "WINDOW=%s → has_rear_windows=%s",
-                self.vehicle_series,
-                door_value,
-                self.has_rear_doors,
-                window_value,
-                self.has_rear_windows,
-            )
         else:
             LOGGER.error(f"No 'info' data found for VIN: {vin}")
             raise ConfigEntryNotReady(

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -14,5 +14,5 @@
     "pycryptodome",
     "saic-ismart-client-ng==0.9.3"
   ],
-  "version": "1.1.2-beta3"
+  "version": "1.1.2"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -14,5 +14,5 @@
     "pycryptodome",
     "saic-ismart-client-ng==0.9.3"
   ],
-  "version": "1.1.2-beta2"
+  "version": "1.1.2-beta3"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -14,5 +14,5 @@
     "pycryptodome",
     "saic-ismart-client-ng==0.9.3"
   ],
-  "version": "1.1.1"
+  "version": "1.1.2-beta1"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -14,5 +14,5 @@
     "pycryptodome",
     "saic-ismart-client-ng==0.9.3"
   ],
-  "version": "1.1.2-beta1"
+  "version": "1.1.2-beta2"
 }


### PR DESCRIPTION
## v1.1.2

This release fixes several climate and entity issues reported across the beta
cycle, and redesigns climate control for the MG S9 PHEV.

### New — proper climate control for the MG S9 PHEV
On the S9 PHEV, the SAIC API's "fan speed" value is actually a fixed climate
*mode* selector, not a fan speed — so the old Low/Med/High slider could never
work correctly. The climate entity has been redesigned for this model to expose:
- **HVAC modes:** Off, Fan only, Cool, Heat
- **Presets:** "Max Cool" (fast strong-fan cool-down) and "Defrost"

This is a per-model scheme — all other models keep their existing fan-speed
slider unchanged.

**⚠️ Breaking change (MG S9 PHEV only):** the fan-speed control is replaced by
HVAC modes + presets. Automations calling `climate.set_fan_mode` on the S9 PHEV
must switch to `climate.set_hvac_mode` (cool / heat / fan_only) or
`climate.set_preset_mode` (Max Cool / Defrost).

### Fixed — rear door/window entities missing on 4-door cars
An earlier change read rear door/window presence from a SAIC API field that
turned out to be unreliable — it reports "no windows" for genuine 4-window cars
(MG4, MGS5) identically to the 2-door Cyberster, which incorrectly removed
their rear window entities. Rear door/window presence is now an explicit
per-model setting; only the Cyberster has them suppressed.

### Fixed — crash / failed setup on transient SAIC server errors
When SAIC's servers return a temporary error (e.g. HTTP 500 on `/vehicle/list`),
the integration no longer crashes or fails setup permanently. It now retries
automatically in the background until SAIC recovers, with no manual reload needed.

### Fixed — climate entity stuck showing "Cool"
The climate entity no longer stays stuck on "Cool" after the car shuts its own
AC off; it now correctly reflects the car's reported state.

### Other
- MGS6 EV climate provisionally moved to the mode-select scheme (cool confirmed;
  remaining modes under verification).
- Improved climate status reverse-mapping (heat/defrost now recognised).

Thanks to @eladrichi, @SteveMSJ, and @Johndowne for the detailed testing and
reports that made these fixes possible.
