### PR TITLE
Add MG India backend using standalone client

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -13,6 +13,15 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: python -m pip install mg-ismart-india-client==0.1.1
+        run: |
+          python -m pip install "$(python - <<'PY'
+          import json
+          from pathlib import Path
+          requirements = json.loads(
+              Path("custom_components/mg_saic/manifest.json").read_text()
+          )["requirements"]
+          print(next(req for req in requirements if req.startswith("mg-ismart-india-client")))
+          PY
+          )"
       - name: Run unit tests
         run: python -m unittest discover -s tests -p "test_*.py"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -12,5 +12,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install test dependencies
+        run: python -m pip install mg-ismart-india-client==0.1.1
       - name: Run unit tests
         run: python -m unittest discover -s tests -p "test_*.py"

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -1,57 +1,83 @@
 # File: backends/india.py
-#
-# India (TAP protocol) backend for the MG/SAIC Home Assistant integration.
-# Based on mg-ismart-india-ha by John Lazarus (github.com/john-lazarus)
-# Copyright (c) 2026 John Lazarus. Licensed under the MIT License.
-#
-# STATUS: SCAFFOLD — this module defines the backend shape, capability set,
-# and PIN handling agreed in issue #169.  The TAP protocol client itself is
-# being contributed by John Lazarus and will replace the NotImplementedError
-# bodies below.  Until then, attempting to set up an India account fails
-# with a clear message rather than the misleading "account is not
-# registered" error from the global gateway.
+from __future__ import annotations
 
-import hashlib
+import time
+from types import SimpleNamespace
+
+from aiohttp import ClientSession
+from mg_ismart_india_client import MgIndiaApiError, MgIndiaClient, hash_control_pin
 
 from ..const import LOGGER
-from . import INDIA_FEATURES, Feature
+from . import INDIA_FEATURES
 
 
 class IndiaBackendNotReadyError(Exception):
-    """Raised while the India TAP client is not yet integrated."""
+    """Backward-compatible name for pre-client scaffold failures."""
 
 
 def hash_india_pin(pin: str) -> str:
-    """Return the MG India command-PIN hash for a 4-digit PIN.
+    """Return the MG India command-PIN hash for a 4-digit PIN."""
+    try:
+        return hash_control_pin(str(pin).strip())
+    except MgIndiaApiError as err:
+        raise ValueError(str(err)) from err
 
-    MG India remote commands are authorised with an uppercase MD5 hex digest
-    of the PIN with "00" appended:  md5(f"{pin}00").hexdigest().upper()
 
-    Confirmed against the iSmart India app by John Lazarus.  Only this hash
-    is stored in the config entry — never the raw PIN.
-    """
-    pin = str(pin).strip()
-    if len(pin) != 4 or not pin.isdigit():
-        raise ValueError("MG India PIN must be exactly 4 digits")
-    return hashlib.md5(f"{pin}00".encode()).hexdigest().upper()
+def _ns(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def _flag(value: bool | None) -> int | None:
+    if value is None:
+        return None
+    return 1 if value else 0
+
+
+def _lock_flag(locked: bool | None) -> int | None:
+    if locked is None:
+        return None
+    return 1 if locked else 0
+
+
+def _tenths(value: float | int | None) -> int | None:
+    if value is None:
+        return None
+    return int(round(float(value) * 10))
+
+
+def _raw_basic(status, key: str, default=None):
+    raw = getattr(status, "raw", None)
+    if isinstance(raw, dict):
+        basic = raw.get("basicVehicleStatus", raw)
+        if isinstance(basic, dict) and key in basic:
+            return basic[key]
+    return default
+
+
+def _vehicle_config(vehicle, code: str, default=None):
+    raw = getattr(vehicle, "raw", None)
+    if isinstance(raw, dict):
+        for block_name in ("configuration", "config", "modelConfig"):
+            block = raw.get(block_name)
+            if isinstance(block, dict) and code in block:
+                return block[code]
+        for item in raw.get("vehicleModelConfiguration", []) or []:
+            if isinstance(item, dict) and item.get("itemCode") == code:
+                return item.get("itemValue", default)
+    return default
+
+
+def _looks_electric(vehicle) -> bool:
+    text = " ".join(str(value or "") for value in (getattr(vehicle, "name", None), getattr(vehicle, "model_name", None), getattr(vehicle, "brand", None), _vehicle_config(vehicle, "EV"), _vehicle_config(vehicle, "BType"))).lower()
+    if str(_vehicle_config(vehicle, "EV", "")).strip() == "1":
+        return True
+    if str(_vehicle_config(vehicle, "BType", "")).strip() == "1":
+        return True
+    return any(token in text for token in ("electric", " ev", "comet", "zs", "windsor"))
 
 
 class IndiaBackend:
-    """Backend for MG India vehicles (TAP binary protocol).
-
-    Conforms to the SAICMGAPIClient method surface for every feature in
-    INDIA_FEATURES.  Charging-related methods are intentionally absent —
-    MG India's platform has no charging data or control, and
-    backend_supports() gates all charging entities/services off before they
-    would ever be called.
-
-    Behavioural notes carried over from the standalone India integration:
-      * Commands require the PIN hash (see hash_india_pin).
-      * Door lock/unlock has a fallback: when MG India returns no terminal
-        result for the command, the backend re-reads vehicle status to
-        confirm the outcome.  This lives entirely inside this backend so
-        the coordinator stays backend-agnostic.
-    """
+    """Backend for MG India vehicles (TAP binary protocol)."""
 
     supported_features = INDIA_FEATURES
 
@@ -62,67 +88,87 @@ class IndiaBackend:
         self.pin_hash = pin_hash
         self.country_code = country_code
         self.region_name = "India"
+        self._session: ClientSession | None = None
+        self._client: MgIndiaClient | None = None
+        self._seat_levels = {"front_left": 0, "front_right": 0}
 
-    def _not_ready(self, what: str):
-        raise IndiaBackendNotReadyError(
-            f"India backend: {what} is not available yet — the India TAP "
-            "client is being integrated (see "
-            "https://github.com/townsmcp/mg-saic-ha/issues/169)."
-        )
+    async def _ensure_client(self) -> MgIndiaClient:
+        if self._client is not None:
+            return self._client
+        self._session = ClientSession()
+        self._client = MgIndiaClient(self._session, self.username, self.password, vin=self.vin, pin_hash=self.pin_hash)
+        return self._client
 
-    # ── Session ──────────────────────────────────────────────────────────────
+    def _set_vin(self, vin: str | None) -> None:
+        if vin:
+            self.vin = vin
+            if self._client is not None:
+                self._client.vin = vin
 
     async def login(self):
-        """Authenticate with the MG India TAP gateway."""
-        LOGGER.error(
-            "MG India support is in development and not functional in this "
-            "release — follow issue #169 for progress."
-        )
-        self._not_ready("login")
+        await (await self._ensure_client()).login()
 
     async def close(self):
-        """Close the client session (nothing to close in the scaffold)."""
-        return None
-
-    # ── Data retrieval (Feature.STATUS) ──────────────────────────────────────
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+        self._client = None
 
     async def get_vehicle_info(self):
-        self._not_ready("vehicle list")
+        client = await self._ensure_client()
+        vehicles = await client.vehicles()
+        if self.vin is None and vehicles:
+            self._set_vin(vehicles[0].vin)
+        return [self._map_vehicle(vehicle) for vehicle in vehicles]
 
     async def get_vehicle_status(self, vin: str | None = None):
-        self._not_ready("vehicle status")
+        self._set_vin(vin)
+        return self._map_status(await (await self._ensure_client()).status())
 
-    # ── Controls (PIN-authorised; capability-gated) ──────────────────────────
+    def _map_vehicle(self, vehicle):
+        model_name = getattr(vehicle, "model_name", None) or getattr(vehicle, "name", None) or "MG India"
+        brand = getattr(vehicle, "brand", None) or "MG"
+        is_electric = _looks_electric(vehicle)
+        configs = [_ns(itemCode="LRD", itemValue=str(_vehicle_config(vehicle, "LRD", "1"))), _ns(itemCode="EV", itemValue="1" if is_electric else "0"), _ns(itemCode="BType", itemValue="1" if is_electric else "0"), _ns(itemCode="ENERGY", itemValue=str(_vehicle_config(vehicle, "ENERGY", "0"))), _ns(itemCode="S35", itemValue=str(_vehicle_config(vehicle, "S35", "0"))), _ns(itemCode="HeatedSeat", itemValue=str(_vehicle_config(vehicle, "HeatedSeat", "0")))]
+        return _ns(vin=vehicle.vin, brandName=brand, modelName=model_name, modelYear=getattr(vehicle, "model_year", None) or "", series=getattr(vehicle, "name", None) or model_name, vehicleModelConfiguration=configs, raw=getattr(vehicle, "raw", None))
 
-    async def lock_vehicle(self, vin):
-        self._not_ready("door lock")
+    def _map_status(self, status):
+        timestamp = getattr(status, "status_time", None) or int(time.time())
+        range_tenths = _tenths(getattr(status, "range_km", None))
+        basic = _ns(lockStatus=_lock_flag(getattr(status, "locked", None)), driverDoor=_flag(getattr(status, "driver_door_open", None)), passengerDoor=_flag(getattr(status, "passenger_door_open", None)), rearLeftDoor=_flag(getattr(status, "rear_left_door_open", None)), rearRightDoor=_flag(getattr(status, "rear_right_door_open", None)), bootStatus=_flag(getattr(status, "boot_open", None)), bonnetStatus=_flag(getattr(status, "bonnet_open", None)), driverWindow=_flag(getattr(status, "driver_window_open", None)), passengerWindow=_flag(getattr(status, "passenger_window_open", None)), rearLeftWindow=_flag(getattr(status, "rear_left_window_open", None)), rearRightWindow=_flag(getattr(status, "rear_right_window_open", None)), sunroofStatus=_flag(getattr(status, "sunroof_open", None)), remoteClimateStatus=(2 if getattr(status, "climate_running", None) is True else 0 if getattr(status, "climate_running", None) is False else None), interiorTemperature=getattr(status, "interior_temperature", None), exteriorTemperature=getattr(status, "exterior_temperature", None), fuelLevelPrc=getattr(status, "fuel_level", None), fuelRange=range_tenths, fuelRangeElec=range_tenths, mileage=_tenths(getattr(status, "odometer_km", None)), batteryVoltage=_tenths(getattr(status, "aux_battery_voltage", None)), canBusActive=_flag(getattr(status, "can_bus_active", None)), timeOfLastCANBUSActivity=getattr(status, "last_can_activity", None), handBrake=_flag(getattr(status, "handbrake", None)), powerMode=_raw_basic(status, "powerMode", 0), engineStatus=_raw_basic(status, "engineStatus", 0), dippedBeamStatus=_raw_basic(status, "dippedBeamStatus", 0), mainBeamStatus=_raw_basic(status, "mainBeamStatus", 0), frontLeftTyrePressure=_raw_basic(status, "frontLeftTyrePressure"), frontRightTyrePressure=_raw_basic(status, "frontRightTyrePressure"), rearLeftTyrePressure=_raw_basic(status, "rearLeftTyrePressure"), rearRightTyrePressure=_raw_basic(status, "rearRightTyrePressure"), frontLeftSeatHeatLevel=_raw_basic(status, "frontLeftSeatHeatLevel", 0), frontRightSeatHeatLevel=_raw_basic(status, "frontRightSeatHeatLevel", 0), secondRowLeftSeatHeatLevel=_raw_basic(status, "secondRowLeftSeatHeatLevel", 0), secondRowRightSeatHeatLevel=_raw_basic(status, "secondRowRightSeatHeatLevel", 0), rmtHtdRrWndSt=_raw_basic(status, "rmtHtdRrWndSt", 0))
+        return _ns(statusTime=timestamp, basicVehicleStatus=basic, gpsPosition=_ns(speed=_raw_basic(status, "speed")), raw=getattr(status, "raw", None))
 
-    async def unlock_vehicle(self, vin):
-        self._not_ready("door unlock")
-
-    async def open_tailgate(self, vin):
-        self._not_ready("tailgate")
+    async def lock_vehicle(self, vin): self._set_vin(vin); await (await self._ensure_client()).control_door_lock(True)
+    async def unlock_vehicle(self, vin): self._set_vin(vin); await (await self._ensure_client()).control_door_lock(False)
+    async def open_tailgate(self, vin): self._set_vin(vin); await (await self._ensure_client()).release_tailgate()
 
     async def control_windows(self, vin, action):
-        self._not_ready("window control")
+        self._set_vin(vin); action = str(action or "").lower()
+        if action in {"open", "ventilate"}: await (await self._ensure_client()).control_windows(True, (9, 10, 11, 12)); return
+        if action == "close": await (await self._ensure_client()).control_windows(False, (9, 10, 11, 12)); return
+        raise MgIndiaApiError(f"Unsupported India window action: {action}")
 
     async def control_sunroof(self, vin, action):
-        self._not_ready("sunroof control")
+        self._set_vin(vin); action = str(action or "").lower()
+        if action not in {"open", "close"}: raise MgIndiaApiError(f"Unsupported India sunroof action: {action}")
+        await (await self._ensure_client()).control_sunroof(action == "open")
 
-    async def start_ac(self, vin, temperature_idx=None):
-        self._not_ready("climate control")
-
-    async def start_climate(self, vin, temperature_idx, fan_speed, ac_on):
-        self._not_ready("climate control")
-
-    async def stop_ac(self, vin):
-        self._not_ready("climate control")
+    async def start_ac(self, vin, temperature_idx=None): self._set_vin(vin); await (await self._ensure_client()).control_climate(True)
+    async def start_climate(self, vin, temperature_idx, fan_speed, ac_on): self._set_vin(vin); await (await self._ensure_client()).control_climate(True)
+    async def stop_ac(self, vin): self._set_vin(vin); await (await self._ensure_client()).control_climate(False)
 
     async def control_heated_seat(self, vin, seat, level):
-        self._not_ready("heated seat control")
+        self._set_vin(vin)
+        if seat not in self._seat_levels: raise MgIndiaApiError(f"India heated-seat control is not confirmed for {seat}")
+        self._seat_levels[seat] = int(level)
+        await (await self._ensure_client()).control_heated_seats(self._seat_levels["front_left"], self._seat_levels["front_right"])
 
     async def control_heated_seats(self, vin, left_side_level=0, right_side_level=0):
-        self._not_ready("heated seat control")
+        self._set_vin(vin); self._seat_levels["front_left"] = int(left_side_level); self._seat_levels["front_right"] = int(right_side_level)
+        await (await self._ensure_client()).control_heated_seats(self._seat_levels["front_left"], self._seat_levels["front_right"])
 
     async def trigger_alarm(self, vin, with_horn=True, with_lights=True, should_stop=False):
-        self._not_ready("find my car")
+        self._set_vin(vin)
+        if should_stop:
+            LOGGER.debug("MG India find-my-car stop requested for VIN %s; no stop command is exposed by the TAP client", vin); return None
+        await (await self._ensure_client()).find_my_car()

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -1,4 +1,8 @@
 # File: backends/india.py
+#
+# India (TAP protocol) backend for the MG/SAIC Home Assistant integration.
+# Based on mg-ismart-india-ha by John Lazarus (github.com/john-lazarus).
+# Copyright (c) 2026 John Lazarus. Licensed under the MIT License.
 from __future__ import annotations
 
 import time
@@ -68,7 +72,16 @@ def _vehicle_config(vehicle, code: str, default=None):
 
 
 def _looks_electric(vehicle) -> bool:
-    text = " ".join(str(value or "") for value in (getattr(vehicle, "name", None), getattr(vehicle, "model_name", None), getattr(vehicle, "brand", None), _vehicle_config(vehicle, "EV"), _vehicle_config(vehicle, "BType"))).lower()
+    text = " ".join(
+        str(value or "")
+        for value in (
+            getattr(vehicle, "name", None),
+            getattr(vehicle, "model_name", None),
+            getattr(vehicle, "brand", None),
+            _vehicle_config(vehicle, "EV"),
+            _vehicle_config(vehicle, "BType"),
+        )
+    ).lower()
     if str(_vehicle_config(vehicle, "EV", "")).strip() == "1":
         return True
     if str(_vehicle_config(vehicle, "BType", "")).strip() == "1":
@@ -96,7 +109,13 @@ class IndiaBackend:
         if self._client is not None:
             return self._client
         self._session = ClientSession()
-        self._client = MgIndiaClient(self._session, self.username, self.password, vin=self.vin, pin_hash=self.pin_hash)
+        self._client = MgIndiaClient(
+            self._session,
+            self.username,
+            self.password,
+            vin=self.vin,
+            pin_hash=self.pin_hash,
+        )
         return self._client
 
     def _set_vin(self, vin: str | None) -> None:
@@ -126,49 +145,182 @@ class IndiaBackend:
         return self._map_status(await (await self._ensure_client()).status())
 
     def _map_vehicle(self, vehicle):
-        model_name = getattr(vehicle, "model_name", None) or getattr(vehicle, "name", None) or "MG India"
+        model_name = (
+            getattr(vehicle, "model_name", None)
+            or getattr(vehicle, "name", None)
+            or "MG India"
+        )
         brand = getattr(vehicle, "brand", None) or "MG"
         is_electric = _looks_electric(vehicle)
-        configs = [_ns(itemCode="LRD", itemValue=str(_vehicle_config(vehicle, "LRD", "1"))), _ns(itemCode="EV", itemValue="1" if is_electric else "0"), _ns(itemCode="BType", itemValue="1" if is_electric else "0"), _ns(itemCode="ENERGY", itemValue=str(_vehicle_config(vehicle, "ENERGY", "0"))), _ns(itemCode="S35", itemValue=str(_vehicle_config(vehicle, "S35", "0"))), _ns(itemCode="HeatedSeat", itemValue=str(_vehicle_config(vehicle, "HeatedSeat", "0")))]
-        return _ns(vin=vehicle.vin, brandName=brand, modelName=model_name, modelYear=getattr(vehicle, "model_year", None) or "", series=getattr(vehicle, "name", None) or model_name, vehicleModelConfiguration=configs, raw=getattr(vehicle, "raw", None))
+        configs = [
+            _ns(itemCode="LRD", itemValue=str(_vehicle_config(vehicle, "LRD", "1"))),
+            _ns(itemCode="EV", itemValue="1" if is_electric else "0"),
+            _ns(itemCode="BType", itemValue="1" if is_electric else "0"),
+            _ns(
+                itemCode="ENERGY",
+                itemValue=str(_vehicle_config(vehicle, "ENERGY", "0")),
+            ),
+            _ns(itemCode="S35", itemValue=str(_vehicle_config(vehicle, "S35", "0"))),
+            _ns(
+                itemCode="HeatedSeat",
+                itemValue=str(_vehicle_config(vehicle, "HeatedSeat", "0")),
+            ),
+        ]
+        return _ns(
+            vin=vehicle.vin,
+            brandName=brand,
+            modelName=model_name,
+            modelYear=getattr(vehicle, "model_year", None) or "",
+            series=getattr(vehicle, "name", None) or model_name,
+            vehicleModelConfiguration=configs,
+            raw=getattr(vehicle, "raw", None),
+        )
 
     def _map_status(self, status):
-        timestamp = getattr(status, "status_time", None) or int(time.time())
+        raw_timestamp = getattr(status, "status_time", None)
+        if raw_timestamp is None:
+            LOGGER.debug(
+                "MG India status payload missing status_time; using local receipt time"
+            )
+            timestamp = int(time.time())
+        else:
+            timestamp = raw_timestamp
         range_tenths = _tenths(getattr(status, "range_km", None))
-        basic = _ns(lockStatus=_lock_flag(getattr(status, "locked", None)), driverDoor=_flag(getattr(status, "driver_door_open", None)), passengerDoor=_flag(getattr(status, "passenger_door_open", None)), rearLeftDoor=_flag(getattr(status, "rear_left_door_open", None)), rearRightDoor=_flag(getattr(status, "rear_right_door_open", None)), bootStatus=_flag(getattr(status, "boot_open", None)), bonnetStatus=_flag(getattr(status, "bonnet_open", None)), driverWindow=_flag(getattr(status, "driver_window_open", None)), passengerWindow=_flag(getattr(status, "passenger_window_open", None)), rearLeftWindow=_flag(getattr(status, "rear_left_window_open", None)), rearRightWindow=_flag(getattr(status, "rear_right_window_open", None)), sunroofStatus=_flag(getattr(status, "sunroof_open", None)), remoteClimateStatus=(2 if getattr(status, "climate_running", None) is True else 0 if getattr(status, "climate_running", None) is False else None), interiorTemperature=getattr(status, "interior_temperature", None), exteriorTemperature=getattr(status, "exterior_temperature", None), fuelLevelPrc=getattr(status, "fuel_level", None), fuelRange=range_tenths, fuelRangeElec=range_tenths, mileage=_tenths(getattr(status, "odometer_km", None)), batteryVoltage=_tenths(getattr(status, "aux_battery_voltage", None)), canBusActive=_flag(getattr(status, "can_bus_active", None)), timeOfLastCANBUSActivity=getattr(status, "last_can_activity", None), handBrake=_flag(getattr(status, "handbrake", None)), powerMode=_raw_basic(status, "powerMode", 0), engineStatus=_raw_basic(status, "engineStatus", 0), dippedBeamStatus=_raw_basic(status, "dippedBeamStatus", 0), mainBeamStatus=_raw_basic(status, "mainBeamStatus", 0), frontLeftTyrePressure=_raw_basic(status, "frontLeftTyrePressure"), frontRightTyrePressure=_raw_basic(status, "frontRightTyrePressure"), rearLeftTyrePressure=_raw_basic(status, "rearLeftTyrePressure"), rearRightTyrePressure=_raw_basic(status, "rearRightTyrePressure"), frontLeftSeatHeatLevel=_raw_basic(status, "frontLeftSeatHeatLevel", 0), frontRightSeatHeatLevel=_raw_basic(status, "frontRightSeatHeatLevel", 0), secondRowLeftSeatHeatLevel=_raw_basic(status, "secondRowLeftSeatHeatLevel", 0), secondRowRightSeatHeatLevel=_raw_basic(status, "secondRowRightSeatHeatLevel", 0), rmtHtdRrWndSt=_raw_basic(status, "rmtHtdRrWndSt", 0))
-        return _ns(statusTime=timestamp, basicVehicleStatus=basic, gpsPosition=_ns(speed=_raw_basic(status, "speed")), raw=getattr(status, "raw", None))
+        basic = _ns(
+            lockStatus=_lock_flag(getattr(status, "locked", None)),
+            driverDoor=_flag(getattr(status, "driver_door_open", None)),
+            passengerDoor=_flag(getattr(status, "passenger_door_open", None)),
+            rearLeftDoor=_flag(getattr(status, "rear_left_door_open", None)),
+            rearRightDoor=_flag(getattr(status, "rear_right_door_open", None)),
+            bootStatus=_flag(getattr(status, "boot_open", None)),
+            bonnetStatus=_flag(getattr(status, "bonnet_open", None)),
+            driverWindow=_flag(getattr(status, "driver_window_open", None)),
+            passengerWindow=_flag(getattr(status, "passenger_window_open", None)),
+            rearLeftWindow=_flag(getattr(status, "rear_left_window_open", None)),
+            rearRightWindow=_flag(getattr(status, "rear_right_window_open", None)),
+            sunroofStatus=_flag(getattr(status, "sunroof_open", None)),
+            remoteClimateStatus=(
+                2
+                if getattr(status, "climate_running", None) is True
+                else 0
+                if getattr(status, "climate_running", None) is False
+                else None
+            ),
+            interiorTemperature=getattr(status, "interior_temperature", None),
+            exteriorTemperature=getattr(status, "exterior_temperature", None),
+            fuelLevelPrc=getattr(status, "fuel_level", None),
+            fuelRange=range_tenths,
+            fuelRangeElec=range_tenths,
+            mileage=_tenths(getattr(status, "odometer_km", None)),
+            batteryVoltage=_tenths(getattr(status, "aux_battery_voltage", None)),
+            canBusActive=_flag(getattr(status, "can_bus_active", None)),
+            timeOfLastCANBUSActivity=getattr(status, "last_can_activity", None),
+            handBrake=_flag(getattr(status, "handbrake", None)),
+            powerMode=_raw_basic(status, "powerMode", 0),
+            engineStatus=_raw_basic(status, "engineStatus", 0),
+            dippedBeamStatus=_raw_basic(status, "dippedBeamStatus", 0),
+            mainBeamStatus=_raw_basic(status, "mainBeamStatus", 0),
+            frontLeftTyrePressure=_raw_basic(status, "frontLeftTyrePressure"),
+            frontRightTyrePressure=_raw_basic(status, "frontRightTyrePressure"),
+            rearLeftTyrePressure=_raw_basic(status, "rearLeftTyrePressure"),
+            rearRightTyrePressure=_raw_basic(status, "rearRightTyrePressure"),
+            frontLeftSeatHeatLevel=_raw_basic(status, "frontLeftSeatHeatLevel", 0),
+            frontRightSeatHeatLevel=_raw_basic(status, "frontRightSeatHeatLevel", 0),
+            secondRowLeftSeatHeatLevel=_raw_basic(
+                status, "secondRowLeftSeatHeatLevel", 0
+            ),
+            secondRowRightSeatHeatLevel=_raw_basic(
+                status, "secondRowRightSeatHeatLevel", 0
+            ),
+            rmtHtdRrWndSt=_raw_basic(status, "rmtHtdRrWndSt", 0),
+        )
+        for seat_key, attr in (
+            ("front_left", "frontLeftSeatHeatLevel"),
+            ("front_right", "frontRightSeatHeatLevel"),
+        ):
+            level = getattr(basic, attr, None)
+            if level is not None:
+                self._seat_levels[seat_key] = int(level)
 
-    async def lock_vehicle(self, vin): self._set_vin(vin); await (await self._ensure_client()).control_door_lock(True)
-    async def unlock_vehicle(self, vin): self._set_vin(vin); await (await self._ensure_client()).control_door_lock(False)
-    async def open_tailgate(self, vin): self._set_vin(vin); await (await self._ensure_client()).release_tailgate()
+        return _ns(
+            statusTime=timestamp,
+            basicVehicleStatus=basic,
+            gpsPosition=_ns(speed=_raw_basic(status, "speed")),
+            raw=getattr(status, "raw", None),
+        )
+
+    async def lock_vehicle(self, vin):
+        self._set_vin(vin)
+        await (await self._ensure_client()).control_door_lock(True)
+
+    async def unlock_vehicle(self, vin):
+        self._set_vin(vin)
+        await (await self._ensure_client()).control_door_lock(False)
+
+    async def open_tailgate(self, vin):
+        self._set_vin(vin)
+        await (await self._ensure_client()).release_tailgate()
 
     async def control_windows(self, vin, action):
-        self._set_vin(vin); action = str(action or "").lower()
-        if action in {"open", "ventilate"}: await (await self._ensure_client()).control_windows(True, (9, 10, 11, 12)); return
-        if action == "close": await (await self._ensure_client()).control_windows(False, (9, 10, 11, 12)); return
+        self._set_vin(vin)
+        action = str(action or "").lower()
+        if action == "ventilate":
+            raise MgIndiaApiError("ventilate not confirmed for India")
+        if action == "open":
+            await (await self._ensure_client()).control_windows(True, (9, 10, 11, 12))
+            return
+        if action == "close":
+            await (await self._ensure_client()).control_windows(False, (9, 10, 11, 12))
+            return
         raise MgIndiaApiError(f"Unsupported India window action: {action}")
 
     async def control_sunroof(self, vin, action):
-        self._set_vin(vin); action = str(action or "").lower()
-        if action not in {"open", "close"}: raise MgIndiaApiError(f"Unsupported India sunroof action: {action}")
+        self._set_vin(vin)
+        action = str(action or "").lower()
+        if action not in {"open", "close"}:
+            raise MgIndiaApiError(f"Unsupported India sunroof action: {action}")
         await (await self._ensure_client()).control_sunroof(action == "open")
 
-    async def start_ac(self, vin, temperature_idx=None): self._set_vin(vin); await (await self._ensure_client()).control_climate(True)
-    async def start_climate(self, vin, temperature_idx, fan_speed, ac_on): self._set_vin(vin); await (await self._ensure_client()).control_climate(True)
-    async def stop_ac(self, vin): self._set_vin(vin); await (await self._ensure_client()).control_climate(False)
+    async def start_ac(self, vin, temperature_idx=None):
+        self._set_vin(vin)
+        await (await self._ensure_client()).control_climate(True)
+
+    async def start_climate(self, vin, temperature_idx, fan_speed, ac_on):
+        self._set_vin(vin)
+        await (await self._ensure_client()).control_climate(True)
+
+    async def stop_ac(self, vin):
+        self._set_vin(vin)
+        await (await self._ensure_client()).control_climate(False)
 
     async def control_heated_seat(self, vin, seat, level):
         self._set_vin(vin)
-        if seat not in self._seat_levels: raise MgIndiaApiError(f"India heated-seat control is not confirmed for {seat}")
+        if seat not in self._seat_levels:
+            raise MgIndiaApiError(
+                f"India heated-seat control is not confirmed for {seat}"
+            )
         self._seat_levels[seat] = int(level)
-        await (await self._ensure_client()).control_heated_seats(self._seat_levels["front_left"], self._seat_levels["front_right"])
+        await (await self._ensure_client()).control_heated_seats(
+            self._seat_levels["front_left"], self._seat_levels["front_right"]
+        )
 
     async def control_heated_seats(self, vin, left_side_level=0, right_side_level=0):
-        self._set_vin(vin); self._seat_levels["front_left"] = int(left_side_level); self._seat_levels["front_right"] = int(right_side_level)
-        await (await self._ensure_client()).control_heated_seats(self._seat_levels["front_left"], self._seat_levels["front_right"])
+        self._set_vin(vin)
+        self._seat_levels["front_left"] = int(left_side_level)
+        self._seat_levels["front_right"] = int(right_side_level)
+        await (await self._ensure_client()).control_heated_seats(
+            self._seat_levels["front_left"], self._seat_levels["front_right"]
+        )
 
-    async def trigger_alarm(self, vin, with_horn=True, with_lights=True, should_stop=False):
+    async def trigger_alarm(
+        self, vin, with_horn=True, with_lights=True, should_stop=False
+    ):
         self._set_vin(vin)
         if should_stop:
-            LOGGER.debug("MG India find-my-car stop requested for VIN %s; no stop command is exposed by the TAP client", vin); return None
+            LOGGER.debug(
+                "MG India find-my-car stop requested for VIN %s; "
+                "no stop command is exposed by the TAP client",
+                vin,
+            )
+            return None
         await (await self._ensure_client()).find_my_car()

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -12,7 +12,8 @@
   "requirements": [
     "requests",
     "pycryptodome",
-    "saic-ismart-client-ng==0.9.3"
+    "saic-ismart-client-ng==0.9.3",
+    "mg-ismart-india-client==0.1.1"
   ],
   "version": "1.1.4-beta1"
 }

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -121,7 +121,7 @@ class TestIndiaPinHash(unittest.TestCase):
         )
 
     def test_invalid_pins_rejected(self):
-        for bad in ("123", "12345", "12a4", "", "abcd", "12.4"):
+        for bad in ("123", "12345", "123456", "12a4", "", "abcd", "12.4"):
             with self.assertRaises(ValueError, msg=f"accepted {bad!r}"):
                 india.hash_india_pin(bad)
 
@@ -243,30 +243,59 @@ class TestCapabilitySets(unittest.TestCase):
             self.assertTrue(backends.backend_supports(LegacyClient(), feature))
 
 
-class TestIndiaBackendStub(unittest.TestCase):
-    """Until the TAP client is wired in, the stub must fail loudly & clearly.
 
-    John's implementation replaces the method bodies; these tests then get
-    superseded by real behaviour tests in his PR.
-    """
-
+class TestIndiaBackendAdapter(unittest.TestCase):
     def setUp(self):
-        self.backend = india.IndiaBackend(
-            username="u", password="p", vin="VIN1", pin_hash="ABC"
-        )
+        self.backend = india.IndiaBackend(username="9999999999", password="p", vin="VIN1", pin_hash="ABC")
+        self.fake = FakeIndiaClient()
+        self.backend._client = self.fake
 
-    def test_status_raises_not_ready(self):
-        with self.assertRaises(india.IndiaBackendNotReadyError) as ctx:
-            _run(self.backend.get_vehicle_status())
-        self.assertIn("169", str(ctx.exception))
-
-    def test_login_raises_not_ready(self):
-        with self.assertRaises(india.IndiaBackendNotReadyError):
-            _run(self.backend.login())
-
-    def test_close_is_safe(self):
-        # close() must never raise — it runs during teardown paths.
+    def tearDown(self):
         _run(self.backend.close())
+
+    def test_login_delegates_to_client(self):
+        _run(self.backend.login())
+        self.assertTrue(self.fake.logged_in)
+
+    def test_vehicle_info_is_saic_shaped(self):
+        vehicle = _run(self.backend.get_vehicle_info())[0]
+        self.assertEqual(vehicle.vin, "VIN1")
+        self.assertEqual(vehicle.brandName, "MG")
+        self.assertEqual(vehicle.modelName, "Comet EV")
+        configs = {item.itemCode: item.itemValue for item in vehicle.vehicleModelConfiguration}
+        self.assertEqual(configs["LRD"], "1")
+        self.assertEqual(configs["EV"], "1")
+        self.assertEqual(configs["BType"], "1")
+
+    def test_status_is_saic_shaped_and_validator_safe(self):
+        status = _run(self.backend.get_vehicle_status("VIN1"))
+        self.assertGreater(status.statusTime, 1_700_000_000)
+        self.assertEqual(status.basicVehicleStatus.lockStatus, 1)
+        self.assertEqual(status.basicVehicleStatus.driverDoor, 0)
+        self.assertEqual(status.basicVehicleStatus.remoteClimateStatus, 2)
+        self.assertEqual(status.basicVehicleStatus.mileage, 12345)
+        self.assertEqual(status.basicVehicleStatus.fuelRangeElec, 850)
+        self.assertEqual(status.basicVehicleStatus.batteryVoltage, 124)
+        self.assertFalse(status.basicVehicleStatus.fuelRange == 0 and status.basicVehicleStatus.fuelRangeElec == 0 and status.basicVehicleStatus.mileage == 0)
+
+    def test_controls_delegate_to_client(self):
+        _run(self.backend.lock_vehicle("VIN1")); _run(self.backend.unlock_vehicle("VIN1")); _run(self.backend.open_tailgate("VIN1")); _run(self.backend.control_windows("VIN1", "open")); _run(self.backend.control_windows("VIN1", "close")); _run(self.backend.control_sunroof("VIN1", "open")); _run(self.backend.start_ac("VIN1")); _run(self.backend.stop_ac("VIN1")); _run(self.backend.control_heated_seat("VIN1", "front_left", 2)); _run(self.backend.control_heated_seat("VIN1", "front_right", 1)); _run(self.backend.trigger_alarm("VIN1"))
+        self.assertEqual(self.fake.calls, [("lock", True), ("lock", False), ("tailgate",), ("windows", True, (9, 10, 11, 12)), ("windows", False, (9, 10, 11, 12)), ("sunroof", True), ("climate", True), ("climate", False), ("seats", 2, 0), ("seats", 2, 1), ("find",)])
+
+
+class FakeIndiaClient:
+    def __init__(self):
+        self.logged_in = False; self.vin = "VIN1"; self.calls = []
+    async def login(self): self.logged_in = True
+    async def vehicles(self): return [types.SimpleNamespace(vin="VIN1", name="Comet EV", brand="MG", model_name="Comet EV", model_year="2026", raw={"configuration": {"LRD": "1", "EV": "1", "BType": "1"}})]
+    async def status(self): return types.SimpleNamespace(status_time=1_800_000_000, locked=True, driver_door_open=False, passenger_door_open=False, rear_left_door_open=False, rear_right_door_open=False, boot_open=False, bonnet_open=False, driver_window_open=False, passenger_window_open=False, rear_left_window_open=False, rear_right_window_open=False, sunroof_open=False, climate_running=True, interior_temperature=24, exterior_temperature=32, fuel_level=None, range_km=85.0, odometer_km=1234.5, aux_battery_voltage=12.4, can_bus_active=True, last_can_activity=1_800_000_000, handbrake=False, raw={"basicVehicleStatus": {"powerMode": 0}})
+    async def control_door_lock(self, lock): self.calls.append(("lock", lock))
+    async def release_tailgate(self): self.calls.append(("tailgate",))
+    async def control_windows(self, open_windows, ids): self.calls.append(("windows", open_windows, ids))
+    async def control_sunroof(self, open_sunroof): self.calls.append(("sunroof", open_sunroof))
+    async def control_climate(self, on): self.calls.append(("climate", on))
+    async def control_heated_seats(self, driver, passenger): self.calls.append(("seats", driver, passenger))
+    async def find_my_car(self): self.calls.append(("find",))
 
 
 if __name__ == "__main__":

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -116,9 +116,7 @@ class TestIndiaPinHash(unittest.TestCase):
         self.assertEqual(digest, digest.upper())
 
     def test_whitespace_is_stripped(self):
-        self.assertEqual(
-            india.hash_india_pin(" 1234 "), india.hash_india_pin("1234")
-        )
+        self.assertEqual(india.hash_india_pin(" 1234 "), india.hash_india_pin("1234"))
 
     def test_invalid_pins_rejected(self):
         for bad in ("123", "12345", "123456", "12a4", "", "abcd", "12.4"):
@@ -243,10 +241,11 @@ class TestCapabilitySets(unittest.TestCase):
             self.assertTrue(backends.backend_supports(LegacyClient(), feature))
 
 
-
 class TestIndiaBackendAdapter(unittest.TestCase):
     def setUp(self):
-        self.backend = india.IndiaBackend(username="9999999999", password="p", vin="VIN1", pin_hash="ABC")
+        self.backend = india.IndiaBackend(
+            username="9999999999", password="p", vin="VIN1", pin_hash="ABC"
+        )
         self.fake = FakeIndiaClient()
         self.backend._client = self.fake
 
@@ -262,7 +261,9 @@ class TestIndiaBackendAdapter(unittest.TestCase):
         self.assertEqual(vehicle.vin, "VIN1")
         self.assertEqual(vehicle.brandName, "MG")
         self.assertEqual(vehicle.modelName, "Comet EV")
-        configs = {item.itemCode: item.itemValue for item in vehicle.vehicleModelConfiguration}
+        configs = {
+            item.itemCode: item.itemValue for item in vehicle.vehicleModelConfiguration
+        }
         self.assertEqual(configs["LRD"], "1")
         self.assertEqual(configs["EV"], "1")
         self.assertEqual(configs["BType"], "1")
@@ -276,26 +277,120 @@ class TestIndiaBackendAdapter(unittest.TestCase):
         self.assertEqual(status.basicVehicleStatus.mileage, 12345)
         self.assertEqual(status.basicVehicleStatus.fuelRangeElec, 850)
         self.assertEqual(status.basicVehicleStatus.batteryVoltage, 124)
-        self.assertFalse(status.basicVehicleStatus.fuelRange == 0 and status.basicVehicleStatus.fuelRangeElec == 0 and status.basicVehicleStatus.mileage == 0)
+        self.assertFalse(
+            status.basicVehicleStatus.fuelRange == 0
+            and status.basicVehicleStatus.fuelRangeElec == 0
+            and status.basicVehicleStatus.mileage == 0
+        )
 
     def test_controls_delegate_to_client(self):
-        _run(self.backend.lock_vehicle("VIN1")); _run(self.backend.unlock_vehicle("VIN1")); _run(self.backend.open_tailgate("VIN1")); _run(self.backend.control_windows("VIN1", "open")); _run(self.backend.control_windows("VIN1", "close")); _run(self.backend.control_sunroof("VIN1", "open")); _run(self.backend.start_ac("VIN1")); _run(self.backend.stop_ac("VIN1")); _run(self.backend.control_heated_seat("VIN1", "front_left", 2)); _run(self.backend.control_heated_seat("VIN1", "front_right", 1)); _run(self.backend.trigger_alarm("VIN1"))
-        self.assertEqual(self.fake.calls, [("lock", True), ("lock", False), ("tailgate",), ("windows", True, (9, 10, 11, 12)), ("windows", False, (9, 10, 11, 12)), ("sunroof", True), ("climate", True), ("climate", False), ("seats", 2, 0), ("seats", 2, 1), ("find",)])
+        _run(self.backend.lock_vehicle("VIN1"))
+        _run(self.backend.unlock_vehicle("VIN1"))
+        _run(self.backend.open_tailgate("VIN1"))
+        _run(self.backend.control_windows("VIN1", "open"))
+        _run(self.backend.control_windows("VIN1", "close"))
+        with self.assertRaisesRegex(Exception, "ventilate not confirmed"):
+            _run(self.backend.control_windows("VIN1", "ventilate"))
+        _run(self.backend.control_sunroof("VIN1", "open"))
+        _run(self.backend.start_ac("VIN1"))
+        _run(self.backend.stop_ac("VIN1"))
+        _run(self.backend.get_vehicle_status("VIN1"))
+        _run(self.backend.control_heated_seat("VIN1", "front_left", 2))
+        _run(self.backend.control_heated_seat("VIN1", "front_right", 1))
+        _run(self.backend.trigger_alarm("VIN1"))
+        self.assertEqual(
+            self.fake.calls,
+            [
+                ("lock", True),
+                ("lock", False),
+                ("tailgate",),
+                ("windows", True, (9, 10, 11, 12)),
+                ("windows", False, (9, 10, 11, 12)),
+                ("sunroof", True),
+                ("climate", True),
+                ("climate", False),
+                ("seats", 2, 3),
+                ("seats", 2, 1),
+                ("find",),
+            ],
+        )
 
 
 class FakeIndiaClient:
     def __init__(self):
-        self.logged_in = False; self.vin = "VIN1"; self.calls = []
-    async def login(self): self.logged_in = True
-    async def vehicles(self): return [types.SimpleNamespace(vin="VIN1", name="Comet EV", brand="MG", model_name="Comet EV", model_year="2026", raw={"configuration": {"LRD": "1", "EV": "1", "BType": "1"}})]
-    async def status(self): return types.SimpleNamespace(status_time=1_800_000_000, locked=True, driver_door_open=False, passenger_door_open=False, rear_left_door_open=False, rear_right_door_open=False, boot_open=False, bonnet_open=False, driver_window_open=False, passenger_window_open=False, rear_left_window_open=False, rear_right_window_open=False, sunroof_open=False, climate_running=True, interior_temperature=24, exterior_temperature=32, fuel_level=None, range_km=85.0, odometer_km=1234.5, aux_battery_voltage=12.4, can_bus_active=True, last_can_activity=1_800_000_000, handbrake=False, raw={"basicVehicleStatus": {"powerMode": 0}})
-    async def control_door_lock(self, lock): self.calls.append(("lock", lock))
-    async def release_tailgate(self): self.calls.append(("tailgate",))
-    async def control_windows(self, open_windows, ids): self.calls.append(("windows", open_windows, ids))
-    async def control_sunroof(self, open_sunroof): self.calls.append(("sunroof", open_sunroof))
-    async def control_climate(self, on): self.calls.append(("climate", on))
-    async def control_heated_seats(self, driver, passenger): self.calls.append(("seats", driver, passenger))
-    async def find_my_car(self): self.calls.append(("find",))
+        self.logged_in = False
+        self.vin = "VIN1"
+        self.calls = []
+
+    async def login(self):
+        self.logged_in = True
+
+    async def vehicles(self):
+        return [
+            types.SimpleNamespace(
+                vin="VIN1",
+                name="Comet EV",
+                brand="MG",
+                model_name="Comet EV",
+                model_year="2026",
+                raw={"configuration": {"LRD": "1", "EV": "1", "BType": "1"}},
+            )
+        ]
+
+    async def status(self):
+        return types.SimpleNamespace(
+            status_time=1_800_000_000,
+            locked=True,
+            driver_door_open=False,
+            passenger_door_open=False,
+            rear_left_door_open=False,
+            rear_right_door_open=False,
+            boot_open=False,
+            bonnet_open=False,
+            driver_window_open=False,
+            passenger_window_open=False,
+            rear_left_window_open=False,
+            rear_right_window_open=False,
+            sunroof_open=False,
+            climate_running=True,
+            interior_temperature=24,
+            exterior_temperature=32,
+            fuel_level=None,
+            range_km=85.0,
+            odometer_km=1234.5,
+            aux_battery_voltage=12.4,
+            can_bus_active=True,
+            last_can_activity=1_800_000_000,
+            handbrake=False,
+            raw={
+                "basicVehicleStatus": {
+                    "powerMode": 0,
+                    "frontLeftSeatHeatLevel": 1,
+                    "frontRightSeatHeatLevel": 3,
+                }
+            },
+        )
+
+    async def control_door_lock(self, lock):
+        self.calls.append(("lock", lock))
+
+    async def release_tailgate(self):
+        self.calls.append(("tailgate",))
+
+    async def control_windows(self, open_windows, ids):
+        self.calls.append(("windows", open_windows, ids))
+
+    async def control_sunroof(self, open_sunroof):
+        self.calls.append(("sunroof", open_sunroof))
+
+    async def control_climate(self, on):
+        self.calls.append(("climate", on))
+
+    async def control_heated_seats(self, driver, passenger):
+        self.calls.append(("seats", driver, passenger))
+
+    async def find_my_car(self):
+        self.calls.append(("find",))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Draft implementation of the MG India backend using the published standalone client package:

- adds `mg-ismart-india-client==0.1.1` to `manifest.json`
- wires `IndiaBackend` to the package instead of the previous not-ready scaffold
- maps the package's clean vehicle/status dataclasses into the SAIC-shaped objects expected by the existing coordinator/entities
- keeps charging methods absent; India charging remains gated off by `INDIA_FEATURES`
- keeps raw PIN out of config storage; PIN hashing is delegated to the package helper
- updates backend tests for the live adapter path

Package links:

- GitHub: https://github.com/john-lazarus/mg-ismart-india-client
- PyPI: https://pypi.org/project/mg-ismart-india-client/

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'`
- local result: `27 tests OK`

## Notes

Marking this as draft because the adapter mapping should be reviewed carefully against the existing coordinator validators and any real India payload quirks before merge. Charging remains intentionally absent/unimplemented for India.