### PR TITLE
Test and harden India vehicle labels

### DIFF
--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     UPDATE_INTERVAL_GRACE_PERIOD,
     UPDATE_INTERVAL_POWERED,
 )
+from .logic import build_vehicle_options
 from saic_ismart_client_ng import SaicApi
 from saic_ismart_client_ng.model import SaicApiConfiguration
 
@@ -70,6 +71,8 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.india_pin_hash = None
         self.vin = None
         self.vehicles = []
+        self.vehicle_options = {}
+        self.vehicle_label = None
         self.vehicle_type = None
 
         self.has_sunroof = False
@@ -248,7 +251,8 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vehicles = await backend.get_vehicle_info()
             if not vehicles:
                 raise Exception("India vehicle list returned no vehicles")
-            self.vehicles = [getattr(v, "vin", v) for v in vehicles]
+            self.vehicle_options = build_vehicle_options(vehicles)
+            self.vehicles = list(self.vehicle_options)
             LOGGER.info("Fetched India vehicle data successfully.")
         finally:
             with suppress(Exception):
@@ -261,6 +265,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.vehicle_type = user_input["vehicle_type"]  # Store vehicle type
 
             self.vin = selected_vin
+            self.vehicle_label = self.vehicle_options.get(selected_vin, selected_vin)
             return await self.async_step_vehicle_capabilities()
 
         # Filter out VINs that are already configured in HA so the user cannot
@@ -272,10 +277,14 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Every VIN on this account is already set up — nothing to add.
             return self.async_abort(reason="already_configured")
 
+        available_vehicle_options = {
+            vin: self.vehicle_options.get(vin, vin) for vin in available_vehicles
+        }
+
         # Add vehicle_type selection with fallback for user confirmation
         data_schema = vol.Schema(
             {
-                vol.Required("vin"): vol.In(available_vehicles),
+                vol.Required("vin"): vol.In(available_vehicle_options),
                 vol.Required("vehicle_type"): vol.In(["BEV", "PHEV", "HEV", "ICE"]),
             }
         )
@@ -298,7 +307,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.has_window_control = user_input["has_window_control"]
 
             return self.async_create_entry(
-                title=f"MG SAIC - {self.vin}",
+                title=f"MG SAIC - {self.vehicle_label or self.vin}",
                 data={
                     "username": self.username,
                     "password": self.password,

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -21,6 +21,19 @@ def normalize_sunroof_action(action):
     return action_name == "open", action_name
 
 
+def build_vehicle_options(vehicles):
+    """Return VIN option values mapped to privacy-safe display labels."""
+    options = {}
+    for vehicle in vehicles:
+        vin = str(getattr(vehicle, "vin", vehicle))
+        model_name = getattr(vehicle, "modelName", None) or getattr(
+            vehicle, "series", None
+        )
+        label = f"{model_name} (…{vin[-5:]})" if model_name else vin
+        options[vin] = label
+    return options
+
+
 def select_update_interval(
     *,
     is_powered_on,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 import unittest
 
 
@@ -31,6 +32,39 @@ class NormalizeSunroofActionTests(unittest.TestCase):
     def test_rejects_invalid_value(self):
         with self.assertRaises(ValueError):
             LOGIC.normalize_sunroof_action("tilt")
+
+
+class BuildVehicleOptionsTests(unittest.TestCase):
+    def test_uses_model_name_and_masks_vin_in_label(self):
+        vin = "LSJW74096NZ123456"
+        vehicle = SimpleNamespace(vin=vin, modelName="New ZS", series="ZS")
+
+        options = LOGIC.build_vehicle_options([vehicle])
+
+        self.assertEqual(options, {vin: "New ZS (…23456)"})
+
+    def test_uses_series_when_model_name_is_missing(self):
+        vin = "LSJW74096NZ654321"
+        vehicle = SimpleNamespace(vin=vin, modelName="", series="E230")
+
+        options = LOGIC.build_vehicle_options([vehicle])
+
+        self.assertEqual(options, {vin: "E230 (…54321)"})
+
+    def test_falls_back_to_vin_without_model_metadata(self):
+        vin = "LSJW74096NZ111111"
+        vehicle = SimpleNamespace(vin=vin, modelName="", series="")
+
+        options = LOGIC.build_vehicle_options([vehicle])
+
+        self.assertEqual(options, {vin: vin})
+
+    def test_accepts_plain_vin_strings(self):
+        vin = "LSJW74096NZ222222"
+
+        options = LOGIC.build_vehicle_options([vin])
+
+        self.assertEqual(options, {vin: vin})
 
 
 class SelectUpdateIntervalTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

The initial selector fix landed on `beta` while this branch was under review. This follow-up keeps that behaviour and makes the label construction independently testable:

- Extract model-aware vehicle labels into a pure helper.
- Keep the full VIN as the stored option value.
- Show `modelName`, then `series`, with a masked five-character VIN suffix.
- Normalize VIN-like values to strings and retain the VIN-only fallback.
- Preserve the selector and config-entry title behaviour already on `beta`.

Global-region setup remains unchanged.

## Tests

- Added unit coverage for model names, series fallback, missing metadata, and plain VIN strings.
- `python -m unittest discover -s tests -p "test_*.py" -v` — 31 passed.
- Hassfest — 1 integration, 0 invalid.

Fixes #229
