### PR TITLE
Release 1.1.5 — Deep Sleep awareness, Holiday Mode, MG India support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ MG India runs on a completely different backend to the rest of the world (a bina
  
 ### Setting up an India vehicle
  
-Follow the normal configuration steps above and select **India** as your region. You will then be asked for your **4-digit iSmart PIN** — the same PIN you use to authorise commands in the iSmart India app. MG India requires this PIN for all remote commands. Only a secure one-way hash of the PIN is stored by the integration; the PIN itself is never saved.
+Follow the normal configuration steps above and select **India** as your region. You will then be asked for your **4-digit iSmart PIN** — the same PIN you use to authorise commands in the iSmart India app. MG India requires this PIN for all remote commands. Only a secure one-way hash of the PIN is stored by the integration; the PIN itself is never saved. When choosing your vehicle you will see its model name with a shortened VIN (e.g. “MG Comet EV (…0001)”) rather than only the raw VIN.
  
 ### What works for India (confirmed on a real vehicle)
  
@@ -250,6 +250,13 @@ The SAIC API counts each instruction sent to the car as one command. To avoid wa
 Set your preferred temperature (and fan speed, on fan-speed models) **first**, then turn the AC on. The command sent to the car will include whatever settings you have already applied in HA. A complete remote pre-conditioning session uses exactly **2 commands** — one to turn on, one to turn off — leaving one spare for a lock or unlock action.
  
 If you want to change settings while the AC is already running, update the values in HA first, then turn the AC off and back on. This applies your new settings using 2 commands.
+ 
+### Front defrost behaviour
+ 
+Front defrost (the standalone **Front Defrost switch**, and the **Defrost preset** on mode-select models) mirrors the iSmart app exactly, based on decrypted app traffic and a live control test:
+ 
+- **Always runs at 22°C**, regardless of the temperature set on the climate slider — this matches what the app sends. Your own temperature setting is **not** changed by starting defrost, and defrost auto-cancels after roughly 10 minutes, so your preference is intact for the next AC session.
+- **Cannot start while the AC is already running.** The vehicle rejects this (the iSmart app blocks it too, asking you to turn AC Auto off first). Rather than waste one of your limited daily remote commands on a request the car would ignore, the integration does not send it — you get a **persistent notification** explaining the AC must be turned off first, plus a command-error event in the Logbook.
  
 ### Fan-speed models
  

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Mileage Since Last Charge
 - Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value)*
 - Battery Heating Status *(if equipped)*
+- Reachability *(deep-sleep / data-freshness indicator — see [Deep sleep & holiday mode](#deep-sleep--holiday-mode))*
 ### BINARY SENSORS
  
 #### Doors
@@ -195,6 +196,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Heated Steering Wheel *(if equipped — enable "Has Steering Wheel Heat" in options)*
 - Sunroof *(if equipped — currently non-functional on tested models; see note below)*
 - Charging Port Lock *(⚠️ "on" means locked — see Entity States Reference)*
+- Holiday Mode *(slows polling to reduce wake-ups / 12V drain while the car is left for long periods — see [Deep sleep & holiday mode](#deep-sleep--holiday-mode))*
 > **Sunroof note:** the sunroof switch and status are retained but are currently non-functional on tested models (e.g. MGS6 EV), where the SAIC API always reports the sunroof as closed regardless of its real position and no working control command has been identified. The option is off by default. It may be revisited if MG adds sunroof support to the iSmart app.
 ### BUTTONS
 - Trigger Alarm
@@ -340,6 +342,44 @@ This means you can set a long polling interval (e.g. 30 minutes or more) for idl
 > **Multiple vehicles on one account:** The integration uses a single API session and a single message poll loop per SAIC account, regardless of how many vehicles are registered under it. This prevents session conflicts and duplicate API calls.
  
  
+## Deep sleep & holiday mode
+ 
+### Deep sleep (why the car sometimes goes quiet)
+ 
+After a car has been idle for a long time (often around a day), its telematics module goes into a deep sleep to save the 12V battery. While asleep it can still answer *cached* status requests, but it cannot service live commands — these fail with the SAIC "can't reach the car" error (return code 4). This is normal vehicle behaviour, not an integration fault.
+ 
+On **PHEVs** this matters more than on BEVs: a PHEV only recharges its 12V battery while the car is running (driving or, in some cases, charging the main battery), whereas a BEV tops the 12V up from the main traction battery as needed. So a PHEV left parked for a long time is more likely to drift into deep sleep, and — as owners have observed — once it's asleep, often only actually **driving** the car reliably wakes it again.
+ 
+### Reachability sensor
+ 
+The **Reachability** sensor surfaces this at a glance, so you can tell when data may be stale rather than wondering why things have gone quiet. It has three states:
+ 
+- **awake** — the car is powered on, or has reported activity recently
+- **likely_asleep** — the car has reported no activity for longer than the *data staleness threshold* (default 12 hours, configurable); its data may be out of date
+- **unreachable** — a live command recently failed with return code 4 (the car itself confirming it can't be reached)
+The state is inferred from the **car's own reported activity**, not from how often the integration polls — so using holiday mode (below) does not make it read asleep incorrectly.
+ 
+**Attributes** provide supporting evidence (none of which drives the state): `reported_battery_voltage` (see note), `hours_since_activity`, `last_command_unreachable`, `data_age_hours`, and `holiday_mode`.
+ 
+> **Battery voltage note:** the reported aux-battery voltage is shown only as an attribute, never used to decide the state. The vehicle can mis-report its own aux voltage (one owner saw 11.7V reported in HA while a calibrated external monitor read 12.13V at the same moment), so it is surfaced as a rough early-warning hint, clearly labelled as possibly inaccurate.
+ 
+### Holiday mode
+ 
+**Holiday Mode** is a switch that slows the integration's idle polling right down while you're away, to reduce how often the telematics module is woken (and so reduce 12V drain, which is especially useful on PHEVs).
+ 
+- It's a **switch** — on/off at a glance, and easy to use in automations (e.g. turn it on when you set your home alarm for a long trip).
+- It **overrides** the idle polling interval at runtime (default every 12 hours, configurable) — it does **not** change your configured intervals, so turning it off returns you to exactly your previous settings, with nothing to remember or restore.
+- It does **not** slow polling while the car is **charging** or **powered on** — if you've plugged in or are driving, those were deliberate actions and you still get normal updates.
+- It **persists across restarts**, so a Home Assistant reboot while you're away won't silently resume fast polling. Home Assistant still performs one immediate poll on restart so your data is fresh, then resumes the holiday cadence.
+- The `Next Update Time` / `Last Update Time` sensors reflect the holiday cadence automatically, so you can confirm it's active.
+> Holiday mode reduces *Home Assistant's* share of the wake-ups. The car and the official iSmart app also poll it, so for very long storage a dedicated 12V maintenance charger is still the reliable safeguard against a flat battery.
+ 
+### Related options
+ 
+Under the integration's **Configure** menu:
+ 
+- **Holiday mode idle interval (hours)** — how slowly to poll while holiday mode is on (default 12)
+- **Data staleness threshold (hours)** — how long without reported activity before the Reachability sensor reads `likely_asleep` (default 12)
 ## 📋 Entity States Reference
  
 This section lists every possible state for every status and control entity, so you know exactly what to expect when coding dashboards or automations. Home Assistant binary sensors always report the underlying state as **`on`/`off`** — never as descriptive text like "Locked"/"Unlocked" or "Open"/"Closed" — the description below tells you what `on` and `off` actually *mean* for each one. The friendly text ("Open", "Locked", etc.) is only shown in the Lovelace UI because of the entity's device class; the state itself, e.g. as read via `states('binary_sensor...')` in a template, is always `on` or `off`.
@@ -396,6 +436,7 @@ This section lists every possible state for every status and control entity, so 
 | Battery Heating Status | `Off`, `On`, `Error` |
 | Front Left/Right Heated Seat Level | `Off`, `Low`, `Medium`, `High` |
 | Steering Wheel Heat | `Off`, `On` |
+| Reachability | `awake`, `likely_asleep`, `unreachable` |
 | Charging Current Limit *(sensor)* | `0A (Ignore)`, `6A`, `8A`, `16A`, `Max` |
 | Target SOC *(sensor)* | `40`, `50`, `60`, `70`, `80`, `90`, `100` (%) |
  
@@ -491,6 +532,6 @@ India region support is built on the work of [John Lazarus](https://github.com/j
 ## License
  
 This project is licensed under the MIT License. See the LICENSE file for details.
-
+ 
 ## Disclaimer
 THIS PROJECT IS NOT IN ANY WAY ASSOCIATED WITH OR RELATED TO THE SAIC MOTOR OR ANY OF ITS SUBSIDIARIES. The information here and online is for educational and resource purposes only and therefore the developers do not endorse or condone any inappropriate use of it, and take no legal responsibility for the functionality or security of your devices.

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -86,7 +86,36 @@ def _mask_account(acct_key) -> str:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up MG SAIC from a config entry."""
+    """Set up MG SAIC from a config entry.
+
+    Thin wrapper adding a per-entry re-entrancy guard around the real setup
+    (_async_setup_entry_impl). Setup has slow awaited steps (vehicle-info
+    fetch; charging-info timeout); if HA invokes setup again for the SAME entry
+    before the first finishes forwarding platforms — a reload landing mid-setup,
+    or a retry after a slow path — the platforms would be forwarded twice and
+    every platform would raise "Config entry ... has already been setup!".
+    Skipping any overlapping invocation prevents that. The guard is always
+    cleared in the finally, so a failed setup (ConfigEntryNotReady) can still be
+    retried normally.
+    """
+    hass.data.setdefault(DOMAIN, {})
+    in_progress = hass.data[DOMAIN].setdefault("setups_in_progress", set())
+    if entry.entry_id in in_progress:
+        LOGGER.debug(
+            "Setup for entry %s already in progress; skipping overlapping "
+            "invocation.",
+            entry.entry_id,
+        )
+        return False
+    in_progress.add(entry.entry_id)
+    try:
+        return await _async_setup_entry_impl(hass, entry)
+    finally:
+        in_progress.discard(entry.entry_id)
+
+
+async def _async_setup_entry_impl(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up MG SAIC from a config entry (real implementation)."""
     hass.data.setdefault(DOMAIN, {})
     domain = hass.data[DOMAIN]
     domain.setdefault("clients_by_vin", {})

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -108,13 +108,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # "Unclosed client session" warnings on every failed setup).
                 with suppress(Exception):
                     await client.close()
-                # The client is only stored in account_clients after a
-                # successful login, so there is nothing to remove here.
-                # Raise ConfigEntryNotReady so HA retries with backoff and
-                # the original cause is preserved instead of being masked
-                # (issue #230).
                 raise ConfigEntryNotReady(
-                    f"Login to MG SAIC failed for account {acct_key}: {exc}"
+                    "Could not log in to MG SAIC; Home Assistant will retry "
+                    "automatically."
                 ) from exc
             domain["account_clients"][acct_key] = client
             LOGGER.debug("Login successful for account %s", acct_key)

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -108,8 +108,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # "Unclosed client session" warnings on every failed setup).
                 with suppress(Exception):
                     await client.close()
-                domain["clients"].pop(acct_key, None)
-                return False
+                # The client is only stored in account_clients after a
+                # successful login, so there is nothing to remove here.
+                # Raise ConfigEntryNotReady so HA retries with backoff and
+                # the original cause is preserved instead of being masked
+                # (issue #230).
+                raise ConfigEntryNotReady(
+                    f"Login to MG SAIC failed for account {acct_key}: {exc}"
+                ) from exc
             domain["account_clients"][acct_key] = client
             LOGGER.debug("Login successful for account %s", acct_key)
         else:

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -53,6 +53,38 @@ def _account_key(entry: ConfigEntry) -> tuple[str, str]:
     return (entry.data["username"], entry.data.get("region", ""))
 
 
+def _mask_vin(vin) -> str:
+    """Return a VIN with only the last 4 characters visible (issue #234).
+
+    A VIN is a personal identifier; logs should not carry it in full. Short
+    or missing values degrade to a generic placeholder rather than leaking.
+    """
+    if not vin or not isinstance(vin, str) or len(vin) < 4:
+        return "****"
+    return f"…{vin[-4:]}"
+
+
+def _mask_account(acct_key) -> str:
+    """Return a log-safe form of an (username, region) account key (#234).
+
+    The username (often an email or phone number) is reduced to its first
+    character plus its domain-ish tail where present; the region is kept in
+    the clear because it is not identifying.
+    """
+    username = acct_key[0] if isinstance(acct_key, (tuple, list)) else str(acct_key)
+    region = (
+        acct_key[1] if isinstance(acct_key, (tuple, list)) and len(acct_key) > 1 else ""
+    )
+    if not username:
+        masked = "****"
+    elif "@" in username:
+        local, _, domain = username.partition("@")
+        masked = f"{local[:1]}***@{domain}"
+    else:
+        masked = f"{username[:1]}***{username[-1:]}" if len(username) > 2 else "***"
+    return f"({masked}, {region})" if region else masked
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MG SAIC from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -97,15 +129,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             try:
                 await client.login()
             except Exception as exc:
+                # Do NOT log the account key, VIN, or raw backend response at
+                # error level (issue #234): the account key contains the
+                # username, and the raw exception can echo back server text.
+                # Identifiers are masked here; the original exception is still
+                # chained onto ConfigEntryNotReady below, so a full traceback
+                # remains available when debug logging is enabled.
                 LOGGER.error(
-                    "Failed to log in to MG SAIC for account %s (VIN %s): %s",
-                    acct_key,
-                    vin,
-                    exc,
+                    "Failed to log in to MG SAIC for account %s (VIN %s). "
+                    "Home Assistant will retry automatically.",
+                    _mask_account(acct_key),
+                    _mask_vin(vin),
                 )
-                # Release any client-held resources (the India backend owns an
-                # aiohttp.ClientSession that would otherwise leak and emit
-                # "Unclosed client session" warnings on every failed setup).
+                LOGGER.debug("MG SAIC login failure detail", exc_info=exc)
+                # Release any client-held resources (issue #233): the India
+                # backend owns an aiohttp.ClientSession, and the global client
+                # owns an httpx.AsyncClient — both would otherwise leak and
+                # emit "Unclosed client session" warnings on every failed
+                # setup.
                 with suppress(Exception):
                     await client.close()
                 raise ConfigEntryNotReady(

--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -108,8 +108,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # "Unclosed client session" warnings on every failed setup).
                 with suppress(Exception):
                     await client.close()
-                domain["clients"].pop(acct_key, None)
-                return False
+                raise ConfigEntryNotReady(
+                    "Could not log in to MG SAIC; Home Assistant will retry "
+                    "automatically."
+                ) from exc
             domain["account_clients"][acct_key] = client
             LOGGER.debug("Login successful for account %s", acct_key)
         else:

--- a/custom_components/mg_saic/api.py
+++ b/custom_components/mg_saic/api.py
@@ -136,9 +136,14 @@ class SAICMGAPIClient:
             if not self.saic_api.is_logged_in:
                 raise Exception("Login failed")
             LOGGER.debug("Login successful, initializing vehicle APIs.")
-        except Exception as e:
-            LOGGER.error("Failed to log in to MG SAIC API: %s", e)
-            self.saic_api = None
+        except Exception:
+            # Do NOT discard self.saic_api here (issue #233): the object owns
+            # an httpx.AsyncClient, and clearing the reference would leave the
+            # caller's close() with nothing to close, leaking the transport.
+            # The reference is retained so async_setup_entry's cleanup path can
+            # close it; a fresh SaicApi is constructed on the next login
+            # attempt regardless. The raw error is intentionally not logged
+            # here (issue #234) — it is chained by the caller.
             raise
 
     # GET VEHICLE DATA
@@ -857,17 +862,55 @@ class SAICMGAPIClient:
 
     # SESSION MANAGEMENT
     async def close(self):
-        """Close the client session."""
+        """Close the client session and release the underlying transport.
+
+        The pinned saic-ismart-client-ng (0.9.3) exposes no public close on
+        SaicApi, but its internal SaicApiClient owns an httpx.AsyncClient that
+        must be closed or it leaks (issue #233). We try, in order:
+
+          1. a public close()/aclose() on SaicApi, if a future pinned version
+             adds one (preferred — remove the fallback when it does);
+          2. otherwise, close the private httpx.AsyncClient directly.
+
+        The private-attribute path is acceptable *because the dependency
+        version is pinned*: the internal layout cannot change under us without
+        a deliberate pin bump. Any failure to reach it degrades to a logged
+        warning rather than raising, so teardown never fails on cleanup.
+        """
         if self.saic_api is None:
             return
 
+        # 1. Public close, if the library ever grows one.
+        for method_name in ("close", "aclose"):
+            method = getattr(self.saic_api, method_name, None)
+            if callable(method):
+                try:
+                    await method()
+                    LOGGER.info("Closed MG SAIC API session.")
+                except Exception as e:
+                    LOGGER.warning("Error closing MG SAIC API session: %s", e)
+                finally:
+                    self.saic_api = None
+                return
+
+        # 2. Fallback: close the private httpx.AsyncClient directly.
+        #    Attribute path (0.9.3): SaicApi -> _AbstractSaicApi__api_client
+        #    (a SaicApiClient) -> _SaicApiClient__client (an httpx.AsyncClient).
         try:
-            if hasattr(self.saic_api, "close"):
-                await self.saic_api.close()
-                LOGGER.info("Closed MG SAIC API session.")
-            else:
-                LOGGER.debug(
-                    "MG SAIC API session has no close method — nothing to close."
+            api_client = getattr(self.saic_api, "_AbstractSaicApi__api_client", None)
+            http_client = getattr(api_client, "_SaicApiClient__client", None)
+            if http_client is not None and not getattr(
+                http_client, "is_closed", True
+            ):
+                await http_client.aclose()
+                LOGGER.debug("Closed MG SAIC underlying HTTP transport.")
+            elif http_client is None:
+                LOGGER.warning(
+                    "Could not locate MG SAIC HTTP transport to close — the "
+                    "saic-ismart-client-ng internals may have changed. Please "
+                    "report this so the integration can be updated."
                 )
         except Exception as e:
-            LOGGER.error("Error closing MG SAIC API session: %s", e)
+            LOGGER.warning("Error closing MG SAIC HTTP transport: %s", e)
+        finally:
+            self.saic_api = None

--- a/custom_components/mg_saic/binary_sensor.py
+++ b/custom_components/mg_saic/binary_sensor.py
@@ -33,13 +33,24 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
         is_rhd = lrd_value == "1"
 
-        # Set door names based on LHD/RHD
+        # Set door and window names based on LHD/RHD. The SAIC API reports the
+        # front doors and windows as "driver"/"passenger" (driverWindow,
+        # passengerWindow), NOT as left/right — so the physical side depends on
+        # which side the car is driven from. On a RHD car the driver sits front
+        # right, so driverWindow is the FRONT RIGHT window. Previously the front
+        # windows were hardcoded to the LHD assumption (driver = left), which
+        # inverted them on RHD cars (issues #235 and the related report — rear
+        # windows were unaffected because they use explicit left/right fields).
         if is_rhd:
             driver_door_name = "Door Front Right"
             passenger_door_name = "Door Front Left"
+            driver_window_name = "Window Front Right"
+            passenger_window_name = "Window Front Left"
         else:
             driver_door_name = "Door Front Left"
             passenger_door_name = "Door Front Right"
+            driver_window_name = "Window Front Left"
+            passenger_window_name = "Window Front Right"
 
         binary_sensors = [
             SAICMGBinarySensor(
@@ -145,7 +156,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             SAICMGBinarySensor(
                 coordinator,
                 entry,
-                "Window Front Left",
+                driver_window_name,
                 "driverWindow",
                 BinarySensorDeviceClass.WINDOW,
                 "mdi:car-door",
@@ -154,7 +165,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             SAICMGBinarySensor(
                 coordinator,
                 entry,
-                "Window Front Right",
+                passenger_window_name,
                 "passengerWindow",
                 BinarySensorDeviceClass.WINDOW,
                 "mdi:car-door",

--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api import CommandsLimitReachedException
 from .const import (
     DOMAIN,
+    FRONT_DEFROST_TEMP_C,
     LOGGER,
 )
 from .utils import create_device_info
@@ -271,12 +272,35 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         )
         return self.coordinator.get_ac_temperature_idx(temp_clamped)
 
-    async def _send_climate_command(self, mode_value: int, hvac_mode, preset=PRESET_NONE):
+    async def _send_climate_command(
+        self,
+        mode_value: int,
+        hvac_mode,
+        preset=PRESET_NONE,
+        temperature_override: int | None = None,
+    ):
         """Send a climate command using a raw mode/fan integer, update state,
-        and schedule the post-action refresh. Shared by both schemes."""
+        and schedule the post-action refresh. Shared by both schemes.
+
+        temperature_override forces a specific temperature (°C) instead of the
+        user's target temperature — used by front defrost, which the iSmart app
+        always sends at a fixed 22°C regardless of the AC temperature setting
+        (confirmed by decrypted capture: slider at 26°C still sent paramId
+        20=8, i.e. 22°C). The user's target temperature is deliberately NOT
+        changed by this: the app keeps displaying the user's own setting too,
+        and overwriting it would lose their preference when defrost auto-cancels
+        after ~10 minutes.
+        """
+        if temperature_override is not None:
+            temperature_idx = self.coordinator.get_ac_temperature_idx(
+                temperature_override
+            )
+        else:
+            temperature_idx = self._temperature_idx()
+
         await self._client.start_climate(
             self._vin,
-            temperature_idx=self._temperature_idx(),
+            temperature_idx=temperature_idx,
             fan_speed=mode_value,
             ac_on=True,
         )
@@ -368,8 +392,20 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
                     c.climate_mode_max_cool, HVACMode.COOL, preset=PRESET_MAX_COOL
                 )
             elif preset_mode == PRESET_DEFROST:
+                # The vehicle will not start front defrost while the AC is
+                # already running (the iSmart app blocks this client-side and
+                # tells the user to turn AC Auto mode off first). Mirror that
+                # rather than sending a command the car ignores.
+                if c.is_climate_blocking_defrost():
+                    await c.notify_front_defrost_blocked(
+                        self._vin, "climate.set_preset_mode"
+                    )
+                    return
                 await self._send_climate_command(
-                    c.climate_mode_defrost, HVACMode.COOL, preset=PRESET_DEFROST
+                    c.climate_mode_defrost,
+                    HVACMode.COOL,
+                    preset=PRESET_DEFROST,
+                    temperature_override=FRONT_DEFROST_TEMP_C,
                 )
             elif preset_mode == PRESET_NONE:
                 # Returning to "none" means plain cool (auto fan).

--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -68,6 +68,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.custom_region_code = None
         self.custom_tenant_id = None
         self.india_pin_hash = None
+        self.vehicle_labels = {}
         self.vin = None
         self.vehicles = []
         self.vehicle_type = None
@@ -248,7 +249,19 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vehicles = await backend.get_vehicle_info()
             if not vehicles:
                 raise Exception("India vehicle list returned no vehicles")
-            self.vehicles = [getattr(v, "vin", v) for v in vehicles]
+            self.vehicles = []
+            self.vehicle_labels = {}
+            for v in vehicles:
+                vin_value = getattr(v, "vin", v)
+                self.vehicles.append(vin_value)
+                # Human-friendly label (issue #229): prefer the model name,
+                # fall back to the series, and append a masked VIN suffix so
+                # two cars of the same model remain distinguishable.  A
+                # vehicle without metadata falls back to its plain VIN.
+                model = getattr(v, "modelName", None) or getattr(v, "series", None)
+                self.vehicle_labels[vin_value] = (
+                    f"{model} (…{vin_value[-4:]})" if model else vin_value
+                )
             LOGGER.info("Fetched India vehicle data successfully.")
         finally:
             with suppress(Exception):
@@ -275,7 +288,15 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Add vehicle_type selection with fallback for user confirmation
         data_schema = vol.Schema(
             {
-                vol.Required("vin"): vol.In(available_vehicles),
+                # Mapping form: keys are the stored values (VINs), values are
+                # the labels shown to the user (issue #229).  Vehicles without
+                # model metadata fall back to showing the plain VIN.
+                vol.Required("vin"): vol.In(
+                    {
+                        v: self.vehicle_labels.get(v, v)
+                        for v in available_vehicles
+                    }
+                ),
                 vol.Required("vehicle_type"): vol.In(["BEV", "PHEV", "HEV", "ICE"]),
             }
         )
@@ -298,7 +319,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.has_window_control = user_input["has_window_control"]
 
             return self.async_create_entry(
-                title=f"MG SAIC - {self.vin}",
+                title=f"MG SAIC - {self.vehicle_labels.get(self.vin, self.vin)}",
                 data={
                     "username": self.username,
                     "password": self.password,

--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     UPDATE_INTERVAL_GRACE_PERIOD,
     UPDATE_INTERVAL_POWERED,
 )
+from .logic import build_vehicle_options
 from saic_ismart_client_ng import SaicApi
 from saic_ismart_client_ng.model import SaicApiConfiguration
 
@@ -70,6 +71,8 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.india_pin_hash = None
         self.vin = None
         self.vehicles = []
+        self.vehicle_options = {}
+        self.vehicle_label = None
         self.vehicle_type = None
 
         self.has_sunroof = False
@@ -248,7 +251,8 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vehicles = await backend.get_vehicle_info()
             if not vehicles:
                 raise Exception("India vehicle list returned no vehicles")
-            self.vehicles = [getattr(v, "vin", v) for v in vehicles]
+            self.vehicle_options = build_vehicle_options(vehicles)
+            self.vehicles = list(self.vehicle_options)
             LOGGER.info("Fetched India vehicle data successfully.")
         finally:
             with suppress(Exception):
@@ -261,6 +265,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.vehicle_type = user_input["vehicle_type"]  # Store vehicle type
 
             self.vin = selected_vin
+            self.vehicle_label = self.vehicle_options.get(selected_vin, selected_vin)
             return await self.async_step_vehicle_capabilities()
 
         # Filter out VINs that are already configured in HA so the user cannot
@@ -272,10 +277,14 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Every VIN on this account is already set up — nothing to add.
             return self.async_abort(reason="already_configured")
 
+        available_vehicle_options = {
+            vin: self.vehicle_options.get(vin, vin) for vin in available_vehicles
+        }
+
         # Add vehicle_type selection with fallback for user confirmation
         data_schema = vol.Schema(
             {
-                vol.Required("vin"): vol.In(available_vehicles),
+                vol.Required("vin"): vol.In(available_vehicle_options),
                 vol.Required("vehicle_type"): vol.In(["BEV", "PHEV", "HEV", "ICE"]),
             }
         )
@@ -298,7 +307,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.has_window_control = user_input["has_window_control"]
 
             return self.async_create_entry(
-                title=f"MG SAIC - {self.vin}",
+                title=f"MG SAIC - {self.vehicle_label or self.vin}",
                 data={
                     "username": self.username,
                     "password": self.password,

--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -9,6 +9,10 @@ from homeassistant.core import callback
 from .backends import REGION_INDIA, create_backend
 from .backends.india import IndiaBackendNotReadyError, hash_india_pin
 from .const import (
+    CONF_HOLIDAY_UPDATE_INTERVAL,
+    CONF_STALE_DATA_THRESHOLD,
+    DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
+    DEFAULT_STALE_DATA_THRESHOLD_HOURS,
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CONF_HAS_BATTERY_HEATING,
     CONF_HAS_HEATED_SEATS,
@@ -487,6 +491,24 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
                     "update_interval",
                     default=self.options.get(
                         "update_interval", self.get_minutes(UPDATE_INTERVAL)
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                # Holiday-mode idle interval (HOURS) and stale-data threshold
+                # (HOURS). Holiday mode itself is toggled via its switch entity,
+                # not here — these just tune its interval and the reachability
+                # sensor's "likely asleep" threshold.
+                vol.Optional(
+                    CONF_HOLIDAY_UPDATE_INTERVAL,
+                    default=self.options.get(
+                        CONF_HOLIDAY_UPDATE_INTERVAL,
+                        DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                vol.Optional(
+                    CONF_STALE_DATA_THRESHOLD,
+                    default=self.options.get(
+                        CONF_STALE_DATA_THRESHOLD,
+                        DEFAULT_STALE_DATA_THRESHOLD_HOURS,
                     ),
                 ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 vol.Optional(

--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     UPDATE_INTERVAL_GRACE_PERIOD,
     UPDATE_INTERVAL_POWERED,
 )
+from .logic import build_vehicle_options
 from saic_ismart_client_ng import SaicApi
 from saic_ismart_client_ng.model import SaicApiConfiguration
 
@@ -68,9 +69,10 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.custom_region_code = None
         self.custom_tenant_id = None
         self.india_pin_hash = None
-        self.vehicle_labels = {}
         self.vin = None
         self.vehicles = []
+        self.vehicle_options = {}
+        self.vehicle_label = None
         self.vehicle_type = None
 
         self.has_sunroof = False
@@ -249,19 +251,8 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vehicles = await backend.get_vehicle_info()
             if not vehicles:
                 raise Exception("India vehicle list returned no vehicles")
-            self.vehicles = []
-            self.vehicle_labels = {}
-            for v in vehicles:
-                vin_value = getattr(v, "vin", v)
-                self.vehicles.append(vin_value)
-                # Human-friendly label (issue #229): prefer the model name,
-                # fall back to the series, and append a masked VIN suffix so
-                # two cars of the same model remain distinguishable.  A
-                # vehicle without metadata falls back to its plain VIN.
-                model = getattr(v, "modelName", None) or getattr(v, "series", None)
-                self.vehicle_labels[vin_value] = (
-                    f"{model} (…{vin_value[-4:]})" if model else vin_value
-                )
+            self.vehicle_options = build_vehicle_options(vehicles)
+            self.vehicles = list(self.vehicle_options)
             LOGGER.info("Fetched India vehicle data successfully.")
         finally:
             with suppress(Exception):
@@ -274,6 +265,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.vehicle_type = user_input["vehicle_type"]  # Store vehicle type
 
             self.vin = selected_vin
+            self.vehicle_label = self.vehicle_options.get(selected_vin, selected_vin)
             return await self.async_step_vehicle_capabilities()
 
         # Filter out VINs that are already configured in HA so the user cannot
@@ -285,18 +277,14 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Every VIN on this account is already set up — nothing to add.
             return self.async_abort(reason="already_configured")
 
+        available_vehicle_options = {
+            vin: self.vehicle_options.get(vin, vin) for vin in available_vehicles
+        }
+
         # Add vehicle_type selection with fallback for user confirmation
         data_schema = vol.Schema(
             {
-                # Mapping form: keys are the stored values (VINs), values are
-                # the labels shown to the user (issue #229).  Vehicles without
-                # model metadata fall back to showing the plain VIN.
-                vol.Required("vin"): vol.In(
-                    {
-                        v: self.vehicle_labels.get(v, v)
-                        for v in available_vehicles
-                    }
-                ),
+                vol.Required("vin"): vol.In(available_vehicle_options),
                 vol.Required("vehicle_type"): vol.In(["BEV", "PHEV", "HEV", "ICE"]),
             }
         )
@@ -319,7 +307,7 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.has_window_control = user_input["has_window_control"]
 
             return self.async_create_entry(
-                title=f"MG SAIC - {self.vehicle_labels.get(self.vin, self.vin)}",
+                title=f"MG SAIC - {self.vehicle_label or self.vin}",
                 data={
                     "username": self.username,
                     "password": self.password,

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -227,6 +227,26 @@ VEHICLE_PROFILES = {
         #   2 = cool (auto fan, follows target temp)  — CONFIRMED
         #   5 = defrost / front windscreen            — CONFIRMED (front demist)
         #   0 = off                                   — CONFIRMED
+        #
+        # Front defrost detail (decrypted capture 2026-07-15): the app sends
+        # rvcReqType=6 with paramId 19=5 AND paramId 20=8 — i.e. mode 5 bundled
+        # with temperature index 8 = 22°C. It does NOT drop the temperature to
+        # minimum; the A/C running during defrost is inherent to demisting
+        # (dehumidification), not a cold setpoint. The car auto-cancels defrost
+        # after ~10 minutes (the app warns of this) and remoteClimateStatus
+        # returns to 0. The library's start_front_defrost() sends exactly the
+        # same thing (fan_speed=5, temperature_idx=8), so the Front Defrost
+        # SWITCH matches the app byte-for-byte.
+        #   CAVEAT: the climate entity's "Defrost" PRESET instead sends the
+        #   user's current target temperature (see _send_climate_command), so
+        #   the two paths can differ. Both MG's app and the library hardcode
+        #   22°C, which hints 22°C is the expected pairing — whether the car
+        #   honours defrost at other temperatures is unconfirmed.
+        #
+        # Rear defrost is NOT part of this mode enum: it is a separate command
+        # (rvcReqType=32, paramId 23=1) that sets rmtHtdRrWndSt and leaves
+        # remoteClimateStatus untouched at 0, running concurrently with any
+        # climate mode. It is therefore a standalone switch, never a preset.
         # Heat / max-cool / fan-only were NOT observed via the app on this model
         # (the app has no such controls), so those values are best-effort
         # inherited defaults and may not do anything on the MGS6.
@@ -482,11 +502,35 @@ WINDOW_STATUS_FIELDS = (
     "rearRightWindow",
 )
 
-# remoteClimateStatus is a "remote climate mode" enum. Values seen in decrypted
-# MGS6 (MIS3E) captures:
+# remoteClimateStatus is a "climate mode" enum. Under the mode_select scheme the
+# value SENT in paramId 19 is echoed back verbatim in this field, so the mode
+# values and the status values are the same number. Values confirmed from
+# decrypted MGS6 (MIS3E) captures:
 #   0 = off
-#   2 = remote climate active — this reports the A/C / HVAC
-#   6 = observed during a sunroof session (not fully mapped; TODO)
+#   2 = cool / A/C running (remote session; car off)
+#   5 = front defrost (confirmed: app sends rvcReqType=6 paramId 19=5 with
+#       paramId 20=8, i.e. a bundled 22°C; status then reads 5, and the car
+#       auto-cancels it after ~10 minutes)
+#   6 = climate running under LOCAL (in-car) control — see below
+#
+# On value 6 — the control SOURCE, not a separate mode. CONFIRMED by test.
+# Across all captures every remoteClimateStatus=2 observation had the car OFF
+# (engineStatus=0, powerMode=0), i.e. a genuine remote session, while the =6
+# observation had the car ON and being driven (engineStatus=1, powerMode=2,
+# 12V at 13.9V with the DC-DC running, new journey ID, key seen, alarm
+# disarmed). So 6 means "the climate is on, but the driver is operating it
+# locally in the car", not a remote command.
+#
+# The decisive control test (2026-07-17): car powered ON (engineStatus=1,
+# powerMode=2, 12V=13.9V) with the climate switched OFF reads
+# remoteClimateStatus = 0 — NOT 6. This rules out the alternative reading that
+# 6 is merely a "car is on / local-control mode" flag that would appear
+# regardless of the HVAC. 6 therefore requires the climate to actually be
+# running, under local control.
+#   (An earlier comment here attributed 6 to "a sunroof session". That was
+#   wrong: the capture in question contained no control commands at all, and
+#   this vehicle has no sunroof (S35 Sunroof itemValue='0'). What it actually
+#   recorded was the owner getting in and driving away with the climate on.)
 #
 # IMPORTANT — ventilation is NOT reliably represented here. An earlier
 # assumption that remoteClimateStatus=2 covered ventilation was DISPROVEN by a
@@ -499,8 +543,23 @@ WINDOW_STATUS_FIELDS = (
 # coordinator.ventilation_active), reflecting the last ventilate command sent
 # from Home Assistant. Ventilation triggered from the iSmart app is not
 # reflected — a known, documented gap.
+# Front defrost always runs at a fixed 22°C. Both MG's iSmart app and the
+# saic-ismart-client-ng library hardcode this: the app sends rvcReqType=6 with
+# paramId 19=5 (defrost) AND paramId 20=8 (temperature index 8 = 22°C), and the
+# library's start_front_defrost() does the same (fan_speed=5, temperature_idx=8).
+# The integration therefore forces 22°C for front defrost on BOTH paths — the
+# Front Defrost switch and the climate "Defrost" preset — rather than sending
+# whatever target temperature the user happens to have on the slider. This keeps
+# the two paths byte-identical to each other and to the app, and avoids sending
+# the car a defrost/temperature pairing that has never been observed in the
+# wild (it is unconfirmed whether the car honours defrost at other temps).
+FRONT_DEFROST_TEMP_C = 22
+
+
 REMOTE_CLIMATE_STATUS_OFF = 0
 REMOTE_CLIMATE_STATUS_ACTIVE = 2  # reports A/C / HVAC (NOT a ventilation flag)
+REMOTE_CLIMATE_STATUS_DEFROST = 5  # front defrost (mode value echoed back)
+REMOTE_CLIMATE_STATUS_LOCAL = 6  # climate RUNNING under local (in-car) control
 
 # Heated seat control (rvcReqType=5, HEATED_SEATS). Each seat is addressed by
 # its own paramId and sent independently (confirmed via decrypted MGS6 traffic).

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -556,6 +556,41 @@ WINDOW_STATUS_FIELDS = (
 FRONT_DEFROST_TEMP_C = 22
 
 
+# Holiday mode: a runtime override that slows idle polling right down to reduce
+# wake-ups (and, on PHEVs, 12V parasitic drain) while the car is left for long
+# periods — without the user having to edit and later restore their configured
+# intervals. It is a switch (on/off), overrides the configured intervals at
+# runtime only, and is deliberately NOT written back to the config options.
+DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS = 12
+CONF_HOLIDAY_UPDATE_INTERVAL = "holiday_update_interval"
+
+# Deep-sleep / reachability sensor.
+# The API has no "asleep" field, so the state is inferred:
+#   awake         — car powered on, or a recent successful live contact
+#   likely_asleep — car idle beyond the staleness threshold (data may be stale)
+#   unreachable   — a live command recently failed with return code 4 (the car
+#                   itself confirming it can't be reached)
+# The idle basis is the vehicle's OWN reported activity (last_vehicle_activity /
+# powerMode), NOT the time since we last polled — so slowing polling (e.g.
+# holiday mode) does not falsely flip the sensor to asleep.
+#
+# Battery voltage is DELIBERATELY NOT used to drive the state. Field evidence
+# (issue #235) shows the vehicle mis-reports its own aux voltage — HA showed
+# 11.7V while a calibrated external monitor read 12.13V at the same moment —
+# so a fixed voltage threshold would act on an unreliable number. Instead the
+# reported voltage is exposed as a sensor ATTRIBUTE (early-warning evidence,
+# labelled as vehicle-reported and possibly inaccurate) alongside inactivity
+# hours, last command result, and data age.
+VEHICLE_REACHABILITY_AWAKE = "awake"
+VEHICLE_REACHABILITY_LIKELY_ASLEEP = "likely_asleep"
+VEHICLE_REACHABILITY_UNREACHABLE = "unreachable"
+# Hours of vehicle inactivity after which data is treated as possibly stale.
+# Configurable; default sits comfortably inside the observed ~1-day sleep onset.
+DEFAULT_STALE_DATA_THRESHOLD_HOURS = 12
+CONF_STALE_DATA_THRESHOLD = "stale_data_threshold_hours"
+# Remote-command return code that means "can't reach the car right now".
+SAIC_RETURN_CODE_UNREACHABLE = 4
+
 REMOTE_CLIMATE_STATUS_OFF = 0
 REMOTE_CLIMATE_STATUS_ACTIVE = 2  # reports A/C / HVAC (NOT a ventilation flag)
 REMOTE_CLIMATE_STATUS_DEFROST = 5  # front defrost (mode value echoed back)

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1656,6 +1656,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             SAIC_RETURN_CODE_UNREACHABLE,
             getattr(self, "vin", "?"),
         )
+        # Push the new state to entities immediately. A command failure happens
+        # between polls, so without this the Reachability sensor would keep
+        # showing "awake" until the next scheduled refresh (up to hours later in
+        # a long/holiday interval) — which is exactly what #238 reported.
+        self.async_update_listeners()
 
     @property
     def vehicle_reachability(self) -> str:

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -24,6 +24,8 @@ from .const import (
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CHARGING_STATUS_CODES,
     DEFAULT_AC_LONG_INTERVAL,
+    REMOTE_CLIMATE_STATUS_DEFROST,
+    REMOTE_CLIMATE_STATUS_OFF,
     DEFAULT_ALARM_LONG_INTERVAL,
     DEFAULT_BATTERY_HEATING_LONG_INTERVAL,
     DEFAULT_CHARGING_CURRENT_LONG_INTERVAL,
@@ -1413,6 +1415,98 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self._command_error_event_entity.record_command_limit_reached(
                 source or "unknown command"
             )
+
+    def is_climate_blocking_defrost(self) -> bool:
+        """True when a running climate mode would block front defrost.
+
+        The iSmart app refuses to send front defrost while the AC is already
+        running, telling the user to "turn off AC Auto mode" first. This is
+        confirmed by a decrypted capture (2026-07-16): pressing front defrost
+        with the AC on (remoteClimateStatus=2) sent NO command at all — the app
+        blocked it client-side. Only after the AC was switched off
+        (remoteClimateStatus=0) did the defrost command go through.
+
+        We mirror that guard so the user gets a clear, actionable message
+        rather than a command that the vehicle silently ignores — and which
+        would still count against the vehicle's daily remote-command limit.
+
+        Off (0) and defrost itself (5) do not block. Any other active climate
+        mode does: cool / max-cool / heat / fan-only, or 6 (the climate running
+        under local in-car control).
+
+        NOTE: only the cool case (2) is confirmed to be blocked by the app; the
+        other active modes are blocked here on the same principle but are
+        unverified. Over-blocking fails safe — the user is told to turn the AC
+        off, which they can do — whereas under-blocking silently wastes one of
+        the vehicle's limited remote commands.
+        """
+        # Only meaningful on backends that actually offer front defrost. The
+        # India (TAP) backend does not expose front defrost and synthesises
+        # remoteClimateStatus into 0/2 only, so guarding there would wrongly
+        # block on a value that doesn't carry the same meaning. Gate on the
+        # capability so this stays correct if profiles change in future.
+        from .backends import Feature
+
+        if not self.backend_supports(Feature.FRONT_DEFROST):
+            return False
+
+        status = self.data.get("status") if self.data else None
+        basic_status = getattr(status, "basicVehicleStatus", None)
+        if basic_status is None:
+            return False
+        remote_climate = getattr(basic_status, "remoteClimateStatus", None)
+        if remote_climate is None:
+            return False
+        return remote_climate not in (
+            REMOTE_CLIMATE_STATUS_OFF,
+            REMOTE_CLIMATE_STATUS_DEFROST,
+        )
+
+    async def notify_front_defrost_blocked(
+        self, vin: str, source: str | None = None
+    ) -> None:
+        """Fire a persistent notification when front defrost is blocked.
+
+        Mirrors notify_command_limit_reached: raises a persistent notification
+        in the HA UI so the user knows why nothing happened, and records a
+        command_error event so there is a queryable Logbook history.
+
+        Args:
+            vin: the vehicle's VIN.
+            source: short identifier of which control was used, e.g.
+                "switch.front_defrost.turn_on" or "climate.set_preset_mode".
+        """
+        vin_info = getattr(self, "vin_info", None)
+        if vin_info is not None:
+            vehicle_label = f"{vin_info.brandName} {vin_info.modelName} (VIN: {vin})"
+        else:
+            vehicle_label = f"VIN: {vin}"
+
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": "MG SAIC: Front Defrost Blocked",
+                "message": (
+                    f"Front defrost was not started on {vehicle_label} because "
+                    "the air conditioning is already running.\n\n"
+                    "**To fix:** turn the air conditioning off first, then start "
+                    "front defrost.\n\n"
+                    "This mirrors the iSmart app, which also requires AC Auto "
+                    "mode to be turned off before front defrost can be used. The "
+                    "command was not sent, so it has not used up one of the "
+                    "vehicle's limited remote commands."
+                ),
+                "notification_id": f"mg_saic_front_defrost_blocked_{vin}",
+            },
+        )
+        LOGGER.warning(
+            "Front defrost blocked (AC already running) for %s", vehicle_label
+        )
+        self.record_command_error(
+            source or "front_defrost",
+            "Front defrost blocked: the air conditioning is already running",
+        )
 
     def set_ventilation_active(self, active: bool) -> None:
         """Set/clear the optimistic ventilation flag (called by window buttons)."""

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -604,6 +604,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         if not getattr(self, "_action_interval_active", False):
             self._adjust_update_interval()
+            # Notify entities so the Next/Last Update Time sensors reflect the
+            # new interval immediately (e.g. when holiday mode is toggled, which
+            # reschedules without a data fetch). Without this the time sensors
+            # would keep showing the previous schedule until the next poll.
+            self.async_update_listeners()
         else:
             self.next_update_time = utcnow() + self.update_interval
             self.async_update_listeners()

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1010,10 +1010,15 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Set the last update time
         self.last_update_time = datetime.now(timezone.utc)
-        # A successful status update means the car is reachable again — clear
-        # any prior "unreachable" (code 4) flag.
-        self._last_command_unreachable = False
-        self._last_command_unreachable_time = None
+        # Clear the "unreachable" (code 4) flag ONLY when the car is genuinely
+        # awake — i.e. reporting powered-on. A successful *status* poll is NOT
+        # sufficient: the SAIC backend serves cached status even while the car's
+        # telematics is asleep and rejecting live commands, so clearing on any
+        # status success would wrongly show "awake" while commands keep failing
+        # (see #238). A successful command also clears it (see record_command_ok).
+        if self.is_powered_on:
+            self._last_command_unreachable = False
+            self._last_command_unreachable_time = None
 
         # Include capabilities in the returned data
         data["capabilities"] = {
@@ -1108,6 +1113,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 LOGGER.debug(
                     "Updated Last Vehicle Activity: %s", self.last_vehicle_activity
                 )
+            # Genuine detected activity (doors, lock, engine, journey change) is
+            # positive proof the car is awake — clear any stale unreachable flag.
+            # This is distinct from a plain cached-status poll, which is not.
+            self._last_command_unreachable = False
+            self._last_command_unreachable_time = None
 
         # Notify listeners of data changes
         self.async_update_listeners()
@@ -1287,6 +1297,10 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
     # Additional Update Intervals for Actions and Confirmation
     async def schedule_action_refresh(self, vin, immediate_interval, long_interval):
         """Schedule non-blocking follow-up refreshes after an action."""
+        # A command reached this point, which means it succeeded (failures raise
+        # before here) — positive proof the car is reachable, so clear any
+        # unreachable flag. Covers every command centrally.
+        self.note_command_ok()
         self._action_refresh_generation += 1
         generation = self._action_refresh_generation
 
@@ -1612,6 +1626,21 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             "enabled" if enabled else "disabled",
             getattr(self, "vin", "?"),
         )
+
+    def note_command_ok(self) -> None:
+        """Clear the unreachable flag after a command SUCCEEDS.
+
+        A successful remote command is positive proof the car is reachable, so
+        it clears the flag immediately (unlike a status poll, which can be
+        served from cache while the car is asleep).
+        """
+        if self._last_command_unreachable:
+            LOGGER.debug(
+                "Command succeeded; clearing unreachable flag for VIN %s",
+                getattr(self, "vin", "?"),
+            )
+        self._last_command_unreachable = False
+        self._last_command_unreachable_time = None
 
     def note_command_unreachable(self) -> None:
         """Flag that a live command failed with the 'can't reach car' code (4).

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -24,8 +24,16 @@ from .const import (
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CHARGING_STATUS_CODES,
     DEFAULT_AC_LONG_INTERVAL,
+    CONF_HOLIDAY_UPDATE_INTERVAL,
+    CONF_STALE_DATA_THRESHOLD,
+    DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
+    DEFAULT_STALE_DATA_THRESHOLD_HOURS,
     REMOTE_CLIMATE_STATUS_DEFROST,
     REMOTE_CLIMATE_STATUS_OFF,
+    SAIC_RETURN_CODE_UNREACHABLE,
+    VEHICLE_REACHABILITY_AWAKE,
+    VEHICLE_REACHABILITY_LIKELY_ASLEEP,
+    VEHICLE_REACHABILITY_UNREACHABLE,
     DEFAULT_ALARM_LONG_INTERVAL,
     DEFAULT_BATTERY_HEATING_LONG_INTERVAL,
     DEFAULT_CHARGING_CURRENT_LONG_INTERVAL,
@@ -110,6 +118,22 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Next Update Time
         self.next_update_time = None
+        # Holiday mode (runtime poll-rate override), persisted flag from options.
+        self.holiday_mode = config_entry.options.get("holiday_mode", False)
+        self.holiday_update_interval = timedelta(
+            hours=config_entry.options.get(
+                CONF_HOLIDAY_UPDATE_INTERVAL,
+                DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
+            )
+        )
+        self.stale_data_threshold = timedelta(
+            hours=config_entry.options.get(
+                CONF_STALE_DATA_THRESHOLD,
+                DEFAULT_STALE_DATA_THRESHOLD_HOURS,
+            )
+        )
+        self._last_command_unreachable = False
+        self._last_command_unreachable_time = None
         self._action_refresh_task = None
         self._action_refresh_generation = 0
 
@@ -544,6 +568,16 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         self.enable_shutdown_refresh_sequence = options.get(
             "enable_shutdown_refresh_sequence", self.enable_shutdown_refresh_sequence
         )
+        self.holiday_mode = options.get("holiday_mode", self.holiday_mode)
+        self.holiday_update_interval = get_interval(
+            CONF_HOLIDAY_UPDATE_INTERVAL, self.holiday_update_interval
+        )
+        self.stale_data_threshold = timedelta(
+            hours=options.get(
+                CONF_STALE_DATA_THRESHOLD,
+                int(self.stale_data_threshold.total_seconds() / 3600),
+            )
+        )
 
         LOGGER.debug(
             f"Update intervals updated via options: "
@@ -971,6 +1005,10 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Set the last update time
         self.last_update_time = datetime.now(timezone.utc)
+        # A successful status update means the car is reachable again — clear
+        # any prior "unreachable" (code 4) flag.
+        self._last_command_unreachable = False
+        self._last_command_unreachable_time = None
 
         # Include capabilities in the returned data
         data["capabilities"] = {
@@ -1220,6 +1258,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             dc_charging_update_interval=self.dc_charging_update_interval,
             grace_period_update_interval=self.grace_period_update_interval,
             after_shutdown_update_interval=self.after_shutdown_update_interval,
+            holiday_mode=self.holiday_mode,
+            holiday_update_interval=self.holiday_update_interval,
         )
 
         if self.is_powered_on:
@@ -1547,6 +1587,63 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.ventilation_active = False
             self._ventilation_windows_seen_open = False
 
+    async def async_set_holiday_mode(self, enabled: bool) -> None:
+        """Turn holiday mode on/off and persist it.
+
+        Writes ONLY the holiday_mode flag into the config entry options (never
+        the user's configured intervals), which triggers the options update
+        listener -> async_update_options, re-reading the flag and rescheduling
+        the next poll at the holiday (or normal) cadence. Persisting to options
+        means the setting survives a Home Assistant restart — important, since
+        the whole point is to leave the car alone while you're away.
+        """
+        self.holiday_mode = enabled
+        new_options = {**self.config_entry.options, "holiday_mode": enabled}
+        self.hass.config_entries.async_update_entry(
+            self.config_entry, options=new_options
+        )
+        LOGGER.info(
+            "Holiday mode %s for VIN %s",
+            "enabled" if enabled else "disabled",
+            getattr(self, "vin", "?"),
+        )
+
+    def note_command_unreachable(self) -> None:
+        """Flag that a live command failed with the 'can't reach car' code (4).
+
+        Called from command error handling when the SAIC return code is 4. The
+        flag is cleared automatically on the next successful status update.
+        Drives the Vehicle Reachability sensor's 'unreachable' state.
+        """
+        self._last_command_unreachable = True
+        self._last_command_unreachable_time = datetime.now(timezone.utc)
+        LOGGER.debug(
+            "Vehicle reported unreachable (return code %s) for VIN %s",
+            SAIC_RETURN_CODE_UNREACHABLE,
+            getattr(self, "vin", "?"),
+        )
+
+    @property
+    def vehicle_reachability(self) -> str:
+        """Inferred reachability state for the Vehicle Reachability sensor.
+
+        - unreachable:   a live command recently failed with code 4
+        - awake:         car powered on, or recent reported activity
+        - likely_asleep: reported inactivity beyond the stale-data threshold
+        Based on the vehicle's OWN reported activity, not our polling cadence,
+        so slowing polling (holiday mode) does not falsely flip it to asleep.
+        """
+        if self._last_command_unreachable:
+            return VEHICLE_REACHABILITY_UNREACHABLE
+        if self.is_powered_on:
+            return VEHICLE_REACHABILITY_AWAKE
+        last_activity = self.last_vehicle_activity
+        if last_activity is not None:
+            inactive_for = datetime.now(timezone.utc) - last_activity
+            if inactive_for >= self.stale_data_threshold:
+                return VEHICLE_REACHABILITY_LIKELY_ASLEEP
+        return VEHICLE_REACHABILITY_AWAKE
+
     def record_command_error(self, source: str, error: Exception | str) -> None:
         """Record a generic command failure via the command-error Event entity.
 
@@ -1564,6 +1661,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 "climate.set_hvac_mode" or "switch.sunroof.turn_on".
             error: the exception or error message that occurred.
         """
+        # Detect the "can't reach the car" return code (4) from any command
+        # failure and flag reachability. All command errors flow through here,
+        # so this single hook covers every entity without per-handler changes.
+        if f"return code: {SAIC_RETURN_CODE_UNREACHABLE}" in str(error):
+            self.note_command_unreachable()
+
         if self._command_error_event_entity is None:
             return
         try:

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1667,19 +1667,40 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         """Inferred reachability state for the Vehicle Reachability sensor.
 
         - unreachable:   a live command recently failed with code 4
-        - awake:         car powered on, or recent reported activity
-        - likely_asleep: reported inactivity beyond the stale-data threshold
-        Based on the vehicle's OWN reported activity, not our polling cadence,
-        so slowing polling (holiday mode) does not falsely flip it to asleep.
+        - awake:         car powered on, or the car reported recently
+        - likely_asleep: the car has not reported for longer than the
+                         stale-data threshold
+
+        The staleness basis is the vehicle's OWN status timestamp
+        (`statusTime` — when the car last reported to SAIC), NOT our polling
+        cadence, so slowing polling (holiday mode) cannot falsely flip it to
+        asleep. Using statusTime rather than our activity detection also means
+        a car that is awake and returning fresh data reads "awake" even if
+        none of the monitored fields happened to change between polls — the
+        previous behaviour left such a car stuck on "likely_asleep" (reported
+        by @SteveMSJ on #238).
         """
         if self._last_command_unreachable:
             return VEHICLE_REACHABILITY_UNREACHABLE
         if self.is_powered_on:
             return VEHICLE_REACHABILITY_AWAKE
-        last_activity = self.last_vehicle_activity
-        if last_activity is not None:
-            inactive_for = datetime.now(timezone.utc) - last_activity
-            if inactive_for >= self.stale_data_threshold:
+
+        # Prefer the car's own reported timestamp; fall back to detected
+        # activity if the response didn't carry one.
+        reference = None
+        status = self.data.get("status") if self.data else None
+        status_time = getattr(status, "statusTime", None)
+        if status_time is not None:
+            try:
+                reference = datetime.fromtimestamp(status_time, tz=timezone.utc)
+            except (ValueError, OSError, OverflowError):
+                reference = None
+        if reference is None:
+            reference = self.last_vehicle_activity
+
+        if reference is not None:
+            stale_for = datetime.now(timezone.utc) - reference
+            if stale_for >= self.stale_data_threshold:
                 return VEHICLE_REACHABILITY_LIKELY_ASLEEP
         return VEHICLE_REACHABILITY_AWAKE
 

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -47,6 +47,8 @@ def select_update_interval(
     dc_charging_update_interval=None,
     grace_period_update_interval,
     after_shutdown_update_interval,
+    holiday_mode=False,
+    holiday_update_interval=None,
 ):
     """Return the interval that should be used for the current state.
 
@@ -58,6 +60,12 @@ def select_update_interval(
     5. After shutdown window
     6. Default idle interval
     """
+    # Holiday mode: a runtime override to minimise wake-ups while the car is
+    # left for long periods. It overrides the idle/grace/after-shutdown cadence,
+    # but NOT active charging or a powered-on car — if someone has plugged the
+    # car in or is driving it, that was deliberate and they still want updates.
+    holiday_active = holiday_mode and holiday_update_interval is not None
+
     if is_powered_on:
         return powered_update_interval
 
@@ -66,6 +74,10 @@ def select_update_interval(
 
     if is_charging:
         return charging_update_interval
+
+    # Car is idle (not powered, not charging) — holiday mode takes over here.
+    if holiday_active:
+        return holiday_update_interval
 
     if (
         activity_duration <= grace_period_update_interval

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -21,6 +21,19 @@ def normalize_sunroof_action(action):
     return action_name == "open", action_name
 
 
+def build_vehicle_options(vehicles):
+    """Return VIN option values mapped to privacy-safe display labels."""
+    options = {}
+    for vehicle in vehicles:
+        vin = str(getattr(vehicle, "vin", vehicle))
+        model_name = getattr(vehicle, "modelName", None) or getattr(
+            vehicle, "series", None
+        )
+        label = f"{model_name} (…{vin[-5:]})" if model_name else vin
+        options[vin] = label
+    return options
+
+
 def select_update_interval(
     *,
     is_powered_on,

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.4"
+  "version": "1.1.5-beta1"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta10"
+  "version": "1.1.5-beta11"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta4"
+  "version": "1.1.5-beta5"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta2"
+  "version": "1.1.5-beta3"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta5"
+  "version": "1.1.5-beta6"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta11"
+  "version": "1.1.5-beta12"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta7"
+  "version": "1.1.5-beta8"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta9"
+  "version": "1.1.5-beta10"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta12"
+  "version": "1.1.5"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta8"
+  "version": "1.1.5-beta9"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta1"
+  "version": "1.1.5-beta2"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta6"
+  "version": "1.1.5-beta7"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.5-beta3"
+  "version": "1.1.5-beta4"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2694,6 +2694,10 @@ class SAICMGVehicleReachabilitySensor(CoordinatorEntity, SensorEntity):
 
     _attr_icon = "mdi:sleep"
     _attr_device_class = SensorDeviceClass.ENUM
+    # Lets Home Assistant translate the raw state values (which must stay
+    # lowercase snake_case, since automations/templates match on them) into
+    # friendly display labels via translations/<lang>.json -> entity.sensor.
+    _attr_translation_key = "vehicle_reachability"
     _attr_options = [
         VEHICLE_REACHABILITY_AWAKE,
         VEHICLE_REACHABILITY_LIKELY_ASLEEP,

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -601,7 +601,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
 
         # Add sensors
-        sensors.append(SAICMGVehicleReachabilitySensor(coordinator, entry, vin_info, vin))
+        sensors.append(SAICMGVehicleReachabilitySensor(coordinator, entry, vin_info, vin_info.vin))
 
         async_add_entities(sensors, update_before_add=True)
 

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -17,6 +17,9 @@ from .backends import Feature
 from .const import (
     DOMAIN,
     LOGGER,
+    VEHICLE_REACHABILITY_AWAKE,
+    VEHICLE_REACHABILITY_LIKELY_ASLEEP,
+    VEHICLE_REACHABILITY_UNREACHABLE,
     PRESSURE_TO_BAR,
     DATA_DECIMAL_CORRECTION,
     DATA_DECIMAL_CORRECTION_SOC,
@@ -598,6 +601,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
 
         # Add sensors
+        sensors.append(SAICMGVehicleReachabilitySensor(coordinator, entry, vin_info, vin))
+
         async_add_entities(sensors, update_before_add=True)
 
     except Exception as e:
@@ -2676,3 +2681,80 @@ class SAICMGVehicleSpeedSensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return device info."""
         return self._device_info
+
+
+class SAICMGVehicleReachabilitySensor(CoordinatorEntity, SensorEntity):
+    """Multi-state sensor indicating whether the vehicle is reachable / awake.
+
+    States: awake / likely_asleep / unreachable. See coordinator
+    .vehicle_reachability for how the state is inferred. Battery voltage is
+    exposed only as an attribute (evidence), never as the state driver, because
+    the vehicle mis-reports its own aux voltage (issue #235).
+    """
+
+    _attr_icon = "mdi:sleep"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [
+        VEHICLE_REACHABILITY_AWAKE,
+        VEHICLE_REACHABILITY_LIKELY_ASLEEP,
+        VEHICLE_REACHABILITY_UNREACHABLE,
+    ]
+
+    def __init__(self, coordinator, entry, vin_info, vin):
+        """Initialize the reachability sensor."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_name = f"{vin_info.brandName} {vin_info.modelName} Reachability"
+        self._attr_unique_id = f"{entry.entry_id}_{vin}_vehicle_reachability"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return self._device_info
+
+    @property
+    def native_value(self):
+        """Return the current reachability state."""
+        return self.coordinator.vehicle_reachability
+
+    @property
+    def extra_state_attributes(self):
+        """Supporting evidence — none of this drives the state."""
+        attrs = {}
+
+        # Reported aux battery voltage (stored x10). Labelled clearly as
+        # vehicle-reported and possibly inaccurate — it is evidence only.
+        status = self.coordinator.data.get("status") if self.coordinator.data else None
+        basic = getattr(status, "basicVehicleStatus", None)
+        raw_voltage = getattr(basic, "batteryVoltage", None) if basic else None
+        if isinstance(raw_voltage, (int, float)):
+            attrs["reported_battery_voltage"] = round(raw_voltage / 10, 2)
+        attrs["reported_battery_voltage_note"] = (
+            "vehicle-reported; may be inaccurate (see issue #235)"
+        )
+
+        # Hours since the car last reported activity.
+        last_activity = getattr(self.coordinator, "last_vehicle_activity", None)
+        if last_activity is not None:
+            from datetime import datetime, timezone
+
+            delta = datetime.now(timezone.utc) - last_activity
+            attrs["hours_since_activity"] = round(delta.total_seconds() / 3600, 1)
+            attrs["last_activity"] = last_activity.isoformat()
+
+        # Whether the last live command reported the car unreachable (code 4).
+        attrs["last_command_unreachable"] = bool(
+            getattr(self.coordinator, "_last_command_unreachable", False)
+        )
+
+        # Data age (how old the current status is) and whether holiday mode is on.
+        last_update = getattr(self.coordinator, "last_update_time", None)
+        if last_update is not None:
+            from datetime import datetime, timezone
+
+            age = datetime.now(timezone.utc) - last_update
+            attrs["data_age_hours"] = round(age.total_seconds() / 3600, 1)
+        attrs["holiday_mode"] = bool(getattr(self.coordinator, "holiday_mode", False))
+
+        return attrs

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2714,6 +2714,17 @@ class SAICMGVehicleReachabilitySensor(CoordinatorEntity, SensorEntity):
         return self._device_info
 
     @property
+    def available(self):
+        """Always available.
+
+        This sensor exists to report that the vehicle can't be reached, so it
+        must stay available precisely when polls are failing — otherwise it
+        goes unavailable alongside every other sensor at the exact moment the
+        user needs it (reported by @SteveMSJ on #238).
+        """
+        return True
+
+    @property
     def native_value(self):
         """Return the current reachability state."""
         return self.coordinator.vehicle_reachability

--- a/custom_components/mg_saic/services.py
+++ b/custom_components/mg_saic/services.py
@@ -131,6 +131,23 @@ def _get_vehicle_resources(hass: HomeAssistant, vin: str):
     return client, coordinator
 
 
+def _record_command_error(hass: HomeAssistant, vin: str, source: str, error) -> None:
+    """Record a service-call command failure on the vehicle's coordinator.
+
+    Service handlers assign `coordinator` inside their try block, so it may be
+    unbound in the except block — this re-resolves it safely. Best-effort and
+    never raises, so it can't mask the original error.
+
+    This is what feeds the Vehicle Reachability sensor: without it, commands
+    issued via SERVICE CALLS never flagged a return-code-4 failure, so the
+    sensor stayed "awake" while commands were failing (see #238).
+    """
+    try:
+        _, coordinator = _get_vehicle_resources(hass, vin)
+        coordinator.record_command_error(source, error)
+    except Exception:  # noqa: BLE001 - supplementary, must never break the caller
+        pass
+
 
 def _backend_allows(client, vin: str, feature: Feature, service: str) -> bool:
     """Return True if *vin*'s backend supports *feature*, else log and refuse.
@@ -186,6 +203,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error locking vehicle for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.locking_vehicle", e)
 
     async def handle_unlock_vehicle(call: ServiceCall) -> None:
         """Handle the unlock_vehicle service call."""
@@ -206,6 +224,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error unlocking vehicle for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.unlocking_vehicle", e)
 
     async def handle_start_ac(call: ServiceCall) -> None:
         """Handle the start_ac service call."""
@@ -249,6 +268,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error starting AC for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.starting_ac", e)
 
     async def handle_stop_ac(call: ServiceCall) -> None:
         """Handle the stop_ac service call."""
@@ -269,6 +289,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error stopping AC for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.stopping_ac", e)
 
     async def handle_start_climate(call: ServiceCall) -> None:
         """Handle the start_climate service call."""
@@ -316,6 +337,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error starting AC with settings for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.starting_ac_with_settings", e)
 
     async def handle_open_tailgate(call: ServiceCall) -> None:
         """Handle the open_tailgate service call."""
@@ -336,6 +358,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error opening tailgate for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.opening_tailgate", e)
 
     async def handle_trigger_alarm(call: ServiceCall) -> None:
         """Handle the trigger_alarm service call."""
@@ -355,6 +378,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error triggering alarm for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.triggering_alarm", e)
 
     async def handle_start_charging(call: ServiceCall) -> None:
         """Handle the start_charging service call."""
@@ -551,6 +575,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             await coordinator.async_request_refresh()
         except Exception as e:
             LOGGER.error("Error setting scheduled charging for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.setting_scheduled_charging", e)
 
     async def handle_set_charging_current(call: ServiceCall):
         """Handle the service call to set charging current."""
@@ -638,6 +663,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error setting target SOC for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.setting_target_soc", e)
 
     async def handle_control_rear_window_heat(call: ServiceCall) -> None:
         """Handle the control_rear_window_heat service call."""
@@ -659,6 +685,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error controlling rear window heat for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_rear_window_heat", e)
 
     async def handle_control_heated_seats(call: ServiceCall) -> None:
         """Handle the control_heated_seats service call."""
@@ -686,6 +713,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error controlling heated seats for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_heated_seats", e)
 
     async def handle_start_front_defrost(call: ServiceCall) -> None:
         """Handle the start_front_defrost service call."""
@@ -706,6 +734,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error starting front defrost for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.starting_front_defrost", e)
 
     async def handle_update_vehicle_data(call: ServiceCall) -> None:
         """Handle the update_vehicle_data service call."""
@@ -736,6 +765,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error controlling sunroof for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_sunroof", e)
 
     async def handle_control_charging_port_lock(call: ServiceCall) -> None:
         vin = call.data["vin"]
@@ -756,6 +786,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
         except Exception as e:
             LOGGER.error("Error controlling charging port lock for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_charging_port_lock", e)
 
     # Register services
     hass.services.async_register(

--- a/custom_components/mg_saic/services.yaml
+++ b/custom_components/mg_saic/services.yaml
@@ -1,304 +1,923 @@
-control_charging_port_lock:
-  description: "Control the charging port lock (lock/unlock)."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    unlock:
-      description: "True to unlock charging port, false to lock."
-      example: true
-      selector:
-        boolean: {}
+# File: services.py
 
-control_heated_seats:
-  description: "Control the heated seat levels for both front seats."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    left_level:
-      description: "Heating level for the left seat (0 = Off, 1 = Low, 2 = Medium, 3 = High)."
-      example: 2
-      selector:
-        select:
-          options:
-            - "0"
-            - "1"
-            - "2"
-            - "3"
-    right_level:
-      description: "Heating level for the right seat (0 = Off, 1 = Low, 2 = Medium, 3 = High)."
-      example: 3
-      selector:
-        select:
-          options:
-            - "0"
-            - "1"
-            - "2"
-            - "3"
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
+import voluptuous as vol
+
+from .backends import Feature, backend_supports
+from .const import (
+    DOMAIN,
+    LOGGER,
+    ChargeCurrentLimitOption,
+    BatterySoc,
+)
+
+SERVICE_CONTROL_CHARGING_PORT_LOCK = "control_charging_port_lock"
+SERVICE_CONTROL_HEATED_SEATS = "control_heated_seats"
+SERVICE_CONTROL_REAR_WINDOW_HEAT = "control_rear_window_heat"
+SERVICE_CONTROL_SUNROOF = "control_sunroof"
+SERVICE_LOCK_VEHICLE = "lock_vehicle"
+SERVICE_UNLOCK_VEHICLE = "unlock_vehicle"
+SERVICE_START_AC = "start_ac"
+SERVICE_STOP_AC = "stop_ac"
+SERVICE_OPEN_TAILGATE = "open_tailgate"
+SERVICE_SET_BATTERY_HEATING_SCHEDULE = "set_battery_heating_schedule"
+SERVICE_SET_SCHEDULED_CHARGING = "set_scheduled_charging"
+SERVICE_SET_CHARGING_CURRENT_LIMIT = "set_charging_current_limit"
+SERVICE_SET_TARGET_SOC = "set_target_soc"
+SERVICE_START_CLIMATE = "start_climate"
+SERVICE_START_BATTERY_HEATING = "start_battery_heating"
+SERVICE_START_CHARGING = "start_charging"
+SERVICE_START_FRONT_DEFROST = "start_front_defrost"
+SERVICE_STOP_BATTERY_HEATING = "stop_battery_heating"
+SERVICE_STOP_CHARGING = "stop_charging"
+SERVICE_TRIGGER_ALARM = "trigger_alarm"
+SERVICE_UPDATE_VEHICLE_DATA = "update_vehicle_data"
 
 
-control_rear_window_heat:
-  description: "Control the rear window heat."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    action:
-      description: "Action to perform."
-      example: "start"
-      selector:
-        select:
-          options:
-            - "start"
-            - "stop"
+SERVICE_ACTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("action"): cv.boolean,
+    }
+)
 
-control_sunroof:
-  description: "Control the sunroof (open or close)."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    should_open:
-      description: "True to open the sunroof, false to close."
-      example: true
-      selector:
-        boolean: {}
+SERVICE_CONTROL_HEATED_SEAT_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("left_level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
+        vol.Required("right_level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
+    }
+)
 
-lock_vehicle:
-  description: "Lock the vehicle."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+SERVICE_PORT_LOCK_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("unlock"): cv.boolean,
+    }
+)
 
-open_tailgate:
-  description: "Open the vehicle's tailgate."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+SERVICE_REAR_WINDOW_DEFROST_ACTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("action"): vol.In(["start", "stop"]),
+    }
+)
 
-set_battery_heating_schedule:
-  description: "Enable or disable the scheduled (timed) battery heating."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    enable:
-      description: "True to enable the schedule, false to disable it."
-      example: true
-      selector:
-        boolean: {}
-    start_time:
-      description: "Daily start time for battery heating (in your Home Assistant timezone). Required when enabling unless a schedule was previously set."
-      example: "06:30:00"
-      selector:
-        time: {}
+SERVICE_START_AC_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("temperature"): vol.Coerce(float),
+    }
+)
 
-set_scheduled_charging:
-  description: "Set the scheduled charging window and mode."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    mode:
-      description: "Charging schedule mode."
-      example: "until_target_soc"
-      selector:
-        select:
-          options:
-            - "disabled"
-            - "until_target_soc"
-            - "until_scheduled_time"
-    start_time:
-      description: "Charging window start time (as shown in the iSmart app). Optional — falls back to the Scheduled Charging Start entity, then the value last reported by the vehicle."
-      example: "00:30:00"
-      selector:
-        time: {}
-    end_time:
-      description: "Charging window end time (as shown in the iSmart app). Optional — falls back to the Scheduled Charging End entity, then the value last reported by the vehicle."
-      example: "05:30:00"
-      selector:
-        time: {}
+SERVICE_START_CLIMATE_SCHEMA = None
 
-set_charging_current_limit:
-  description: "Set the charging current limit for the vehicle."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    current_limit:
-      description: "Select the desired charging current limit."
-      example: "16A"
-      selector:
-        select:
-          options:
-            - "0 (Ignore)"
-            - "6A"
-            - "8A"
-            - "16A"
-            - "Max"
+SERVICE_SET_CHARGING_CURRENT_LIMIT_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("current_limit"): vol.In(
+            [e.limit for e in ChargeCurrentLimitOption]
+        ),
+    }
+)
 
-set_target_soc:
-  description: "Set the target SOC (State of Charge) for the vehicle."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    target_soc:
-      description: "Desired target SOC percentage (10-100)."
-      example: 80
-      selector:
-        number:
-          min: 10
-          max: 100
-          step: 1
+SERVICE_SET_TARGET_SOC_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("target_soc"): vol.In([40, 50, 60, 70, 80, 90, 100]),
+    }
+)
 
-start_ac:
-  description: "Start the vehicle's AC system."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    temperature:
-      description: "Desired temperature in degrees Celsius."
-      example: 22.0
-      selector:
-        number:
-          min: 16
-          max: 30
-          step: 1
+SERVICE_SET_BATTERY_HEATING_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("enable"): cv.boolean,
+        vol.Optional("start_time"): cv.time,
+    }
+)
 
-start_climate:
-  description: "Start the vehicle's Climate system with temperature and fan settings."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
-    temperature:
-      description: "Desired temperature in degrees Celsius."
-      example: 22.0
-      selector:
-        number:
-          min: 16
-          max: 30
-          step: 1
-    fan_speed:
-      description: "Fan speed level (e.g., 1-5)."
-      example: 3
-      selector:
-        number:
-          min: 1
-          max: 5
-          step: 1
-    ac_on:
-      description: "Turn AC on or off (true = AC ON, false = AC OFF)."
-      example: true
-      selector:
-        boolean: {}
+SERVICE_SET_SCHEDULED_CHARGING_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("mode"): vol.In(
+            ["disabled", "until_target_soc", "until_scheduled_time"]
+        ),
+        vol.Optional("start_time"): cv.time,
+        vol.Optional("end_time"): cv.time,
+    }
+)
 
-start_battery_heating:
-  description: "Start the vehicle battery heating process."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+SERVICE_SUNROOF_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Required("should_open"): cv.boolean,
+    }
+)
 
-start_charging:
-  description: "Start the vehicle charging process."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+SERVICE_VIN_SCHEMA = vol.Schema({vol.Required("vin"): cv.string})
 
-start_front_defrost:
-  description: "Start the front defrost system of the vehicle."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
 
-stop_ac:
-  description: "Stop the vehicle's AC system."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+def _get_vehicle_resources(hass: HomeAssistant, vin: str):
+    """Resolve the client and coordinator for a VIN."""
+    domain_data = hass.data.get(DOMAIN, {})
+    client = domain_data.get("clients_by_vin", {}).get(vin)
+    coordinator = domain_data.get("coordinators_by_vin", {}).get(vin)
 
-stop_battery_heating:
-  description: "Stop the vehicle battery heating process."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+    if client is None or coordinator is None:
+        raise ValueError(f"No integration resources found for VIN {vin}")
 
-stop_charging:
-  description: "Stop the vehicle charging process."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+    return client, coordinator
 
-trigger_alarm:
-  description: "Trigger the vehicle's alarm."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
 
-unlock_vehicle:
-  description: "Unlock the vehicle."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+def _record_command_error(hass: HomeAssistant, vin: str, source: str, error) -> None:
+    """Record a service-call command failure on the vehicle's coordinator.
 
-update_vehicle_data:
-  description: "Manually trigger a data update from the vehicle."
-  fields:
-    vin:
-      description: "Vehicle Identification Number."
-      example: "1HGCM82633A123456"
-      selector:
-        text: {}
+    Service handlers assign `coordinator` inside their try block, so it may be
+    unbound in the except block — this re-resolves it safely. Best-effort and
+    never raises, so it can't mask the original error.
+
+    This is what feeds the Vehicle Reachability sensor: without it, commands
+    issued via SERVICE CALLS never flagged a return-code-4 failure, so the
+    sensor stayed "awake" while commands were failing (see #238).
+    """
+    try:
+        _, coordinator = _get_vehicle_resources(hass, vin)
+        coordinator.record_command_error(source, error)
+    except Exception:  # noqa: BLE001 - supplementary, must never break the caller
+        pass
+
+
+def _backend_allows(client, vin: str, feature: Feature, service: str) -> bool:
+    """Return True if *vin*'s backend supports *feature*, else log and refuse.
+
+    Service calls can target any configured VIN, including vehicles on
+    backends that do not implement the requested command family (e.g. MG
+    India has no charging control — issue #169).  Refusing here, before any
+    client call, guarantees an unsupported command can never reach a real
+    car through the services layer.
+    """
+    if backend_supports(client, feature):
+        return True
+    LOGGER.error(
+        "Service %s is not supported for VIN %s: this vehicle's backend "
+        "(region) does not implement '%s'.",
+        service,
+        vin,
+        feature.value,
+    )
+    return False
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services for the MG SAIC integration."""
+
+    # Dynamically define SERVICE_START_CLIMATE_SCHEMA based on vehicle's temperature limits
+    global SERVICE_START_CLIMATE_SCHEMA
+    SERVICE_START_CLIMATE_SCHEMA = vol.Schema(
+        {
+            vol.Required("vin"): cv.string,
+            vol.Required("temperature"): vol.Coerce(float),
+            vol.Required("fan_speed"): vol.Coerce(int),
+            vol.Optional("ac_on", default=True): cv.boolean,
+        }
+    )
+
+    async def handle_lock_vehicle(call: ServiceCall) -> None:
+        """Handle the lock_vehicle service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.LOCK, "lock_vehicle"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.lock_unlock_long_interval
+
+            await client.lock_vehicle(vin)
+            LOGGER.info("Vehicle locked successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error locking vehicle for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.locking_vehicle", e)
+
+    async def handle_unlock_vehicle(call: ServiceCall) -> None:
+        """Handle the unlock_vehicle service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.LOCK, "unlock_vehicle"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.lock_unlock_long_interval
+
+            await client.unlock_vehicle(vin)
+            LOGGER.info("Vehicle unlocked successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error unlocking vehicle for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.unlocking_vehicle", e)
+
+    async def handle_start_ac(call: ServiceCall) -> None:
+        """Handle the start_ac service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CLIMATE, "start_ac"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.ac_long_interval
+
+            # Retrieve desired temperature from service call
+            temperature = call.data.get("temperature")
+            if temperature is None:
+                LOGGER.error("No temperature provided for start_ac service.")
+                return
+
+            # Clamp the temperature within allowable range
+            clamped_temp = max(
+                coordinator.min_temp, min(coordinator.max_temp, temperature)
+            )
+
+            # Calculate temperature_idx using coordinator's method
+            temperature_idx = coordinator.get_ac_temperature_idx(clamped_temp)
+
+            # Call the start_ac method from api.py
+            await client.start_ac(
+                vin=vin,
+                temperature_idx=temperature_idx,
+            )
+            LOGGER.info(
+                "AC started successfully for VIN: %s with temperature index %d",
+                vin,
+                temperature_idx,
+            )
+
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error starting AC for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.starting_ac", e)
+
+    async def handle_stop_ac(call: ServiceCall) -> None:
+        """Handle the stop_ac service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CLIMATE, "stop_ac"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.ac_long_interval
+
+            await client.stop_ac(vin)
+            LOGGER.info("AC stopped successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error stopping AC for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.stopping_ac", e)
+
+    async def handle_start_climate(call: ServiceCall) -> None:
+        """Handle the start_climate service call."""
+        vin = call.data["vin"]
+        temperature = call.data["temperature"]
+        fan_speed = call.data["fan_speed"]
+        ac_on = call.data["ac_on"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CLIMATE, "start_climate"):
+                return
+            min_temp = coordinator.min_temp
+            max_temp = coordinator.max_temp
+
+            # Clamp temperature within allowable range
+            clamped_temp = max(min_temp, min(max_temp, round(temperature)))
+
+            # Calculate temperature_idx using coordinator's method
+            temperature_idx = coordinator.get_ac_temperature_idx(clamped_temp)
+
+            # Clamp fan speed within allowable range
+            fan_speed = max(1, min(5, fan_speed))
+
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.ac_long_interval
+
+            await client.start_climate(
+                vin=vin,
+                temperature_idx=temperature_idx,
+                fan_speed=fan_speed,
+                ac_on=ac_on,
+            )
+
+            LOGGER.info(
+                "Climate started with AC ON: %s, temperature %s°C and fan speed %s for VIN: %s",
+                ac_on,
+                temperature,
+                fan_speed,
+                vin,
+            )
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error starting AC with settings for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.starting_ac_with_settings", e)
+
+    async def handle_open_tailgate(call: ServiceCall) -> None:
+        """Handle the open_tailgate service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.TAILGATE, "open_tailgate"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.tailgate_long_interval
+
+            await client.open_tailgate(vin)
+            LOGGER.info("Tailgate opened successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error opening tailgate for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.opening_tailgate", e)
+
+    async def handle_trigger_alarm(call: ServiceCall) -> None:
+        """Handle the trigger_alarm service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.FIND_MY_CAR, "trigger_alarm"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.alarm_long_interval
+            await client.trigger_alarm(vin)
+            LOGGER.info("Alarm triggered successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error triggering alarm for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.triggering_alarm", e)
+
+    async def handle_start_charging(call: ServiceCall) -> None:
+        """Handle the start_charging service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CHARGING_CONTROL, "start_charging"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.charging_long_interval
+
+            LOGGER.debug(f"Sending start charging command for VIN: {vin}")
+            await client.send_vehicle_charging_control(vin, "start")
+            LOGGER.info(f"Charging started successfully for VIN: {vin}")
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error(f"Error starting charging for VIN {vin}: {e}")
+
+    async def handle_stop_charging(call: ServiceCall) -> None:
+        """Handle the stop_charging service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CHARGING_CONTROL, "stop_charging"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.charging_long_interval
+
+            LOGGER.debug(f"Sending stop charging command for VIN: {vin}")
+            await client.send_vehicle_charging_control(vin, "stop")
+            LOGGER.info(f"Charging stopped successfully for VIN: {vin}")
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error(f"Error stopping charging for VIN {vin}: {e}")
+
+    async def handle_start_battery_heating(call: ServiceCall) -> None:
+        """Handle the start_battery_heating service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.BATTERY_HEATING, "start_battery_heating"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.battery_heating_long_interval
+
+            LOGGER.debug(f"Sending start battery heating command for VIN: {vin}")
+            await client.send_vehicle_charging_ptc_heat(vin, "start")
+            LOGGER.info(f"Battery heating started successfully for VIN: {vin}")
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error(f"Error starting battery heating for VIN {vin}: {e}")
+
+    async def handle_stop_battery_heating(call: ServiceCall) -> None:
+        """Handle the stop_battery_heating service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.BATTERY_HEATING, "stop_battery_heating"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.battery_heating_long_interval
+
+            LOGGER.debug(f"Sending stop battery heating command for VIN: {vin}")
+            await client.send_vehicle_charging_ptc_heat(vin, "stop")
+            LOGGER.info(f"Battery heating stopped successfully for VIN: {vin}")
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error(f"Error stopping battery heating for VIN {vin}: {e}")
+
+    async def handle_set_battery_heating_schedule(call: ServiceCall) -> None:
+        """Handle the set_battery_heating_schedule service call."""
+        vin = call.data["vin"]
+        enable = call.data["enable"]
+        start_time = call.data.get("start_time")
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.BATTERY_HEATING, "set_battery_heating_schedule"):
+                return
+
+            if enable:
+                tz = dt_util.get_default_time_zone()
+                if start_time is None:
+                    # Fall back to the pending value from the time entity,
+                    # then the schedule last reported by the vehicle.
+                    start_time = coordinator.battery_heating_pending_time
+                    if start_time is None:
+                        schedule = coordinator.data.get("battery_heating_schedule")
+                        if schedule is not None and getattr(schedule, "startTime", 0):
+                            start_time = schedule.decode_start_time(tz)
+                if start_time is None:
+                    LOGGER.error(
+                        "Cannot enable battery heating schedule for VIN %s: "
+                        "no start_time provided and no previous schedule known.",
+                        vin,
+                    )
+                    return
+                coordinator.battery_heating_pending_time = start_time
+                LOGGER.debug(
+                    "Enabling battery heating schedule for VIN %s at %s",
+                    vin,
+                    start_time,
+                )
+                await client.enable_battery_heating_schedule(vin, start_time, tz)
+                LOGGER.info(
+                    "Battery heating schedule enabled at %s for VIN: %s",
+                    start_time,
+                    vin,
+                )
+            else:
+                LOGGER.debug("Disabling battery heating schedule for VIN %s", vin)
+                await client.disable_battery_heating_schedule(vin)
+                LOGGER.info("Battery heating schedule disabled for VIN: %s", vin)
+
+            await coordinator.async_request_refresh()
+        except Exception as e:
+            LOGGER.error(
+                "Error setting battery heating schedule for VIN %s: %s", vin, e
+            )
+
+    async def handle_set_scheduled_charging(call: ServiceCall) -> None:
+        """Handle the set_scheduled_charging service call."""
+        from saic_ismart_client_ng.api.vehicle_charging import ScheduledChargingMode
+
+        from .time import (
+            DEFAULT_SCHEDULED_CHARGING_END,
+            DEFAULT_SCHEDULED_CHARGING_START,
+            decode_scheduled_charging_field,
+        )
+
+        vin = call.data["vin"]
+        mode_key = call.data["mode"]
+        mode = {
+            "disabled": ScheduledChargingMode.DISABLED,
+            "until_target_soc": ScheduledChargingMode.UNTIL_CONFIGURED_SOC,
+            "until_scheduled_time": ScheduledChargingMode.UNTIL_CONFIGURED_TIME,
+        }[mode_key]
+
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.SCHEDULED_CHARGING, "set_scheduled_charging"):
+                return
+
+            charging_data = coordinator.data.get("charging")
+            chrg_mgmt_data = getattr(charging_data, "chrgMgmtData", None)
+
+            start_time = call.data.get("start_time")
+            if start_time is None:
+                start_time = coordinator.scheduled_charging_pending_start
+            if start_time is None:
+                start_time = decode_scheduled_charging_field(
+                    chrg_mgmt_data, "bmsReserStHourDspCmd", "bmsReserStMintueDspCmd"
+                )
+            if start_time is None:
+                start_time = DEFAULT_SCHEDULED_CHARGING_START
+
+            end_time = call.data.get("end_time")
+            if end_time is None:
+                end_time = coordinator.scheduled_charging_pending_end
+            if end_time is None:
+                end_time = decode_scheduled_charging_field(
+                    chrg_mgmt_data, "bmsReserSpHourDspCmd", "bmsReserSpMintueDspCmd"
+                )
+            if end_time is None:
+                end_time = DEFAULT_SCHEDULED_CHARGING_END
+
+            # Keep the time entities in sync with what was sent.
+            coordinator.scheduled_charging_pending_start = start_time
+            coordinator.scheduled_charging_pending_end = end_time
+
+            await client.set_scheduled_charging(vin, start_time, end_time, mode)
+            LOGGER.info(
+                "Scheduled charging set to %s (%s - %s) for VIN: %s",
+                mode_key,
+                start_time,
+                end_time,
+                vin,
+            )
+            await coordinator.async_request_refresh()
+        except Exception as e:
+            LOGGER.error("Error setting scheduled charging for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.setting_scheduled_charging", e)
+
+    async def handle_set_charging_current(call: ServiceCall):
+        """Handle the service call to set charging current."""
+        vin = call.data["vin"]
+        current_limit = call.data["current_limit"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CURRENT_LIMIT, "set_charging_current"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.charging_current_long_interval
+
+            # Map the string option to the local enum
+            selected_code = ChargeCurrentLimitOption.to_code(current_limit)
+
+            # Get the current target_soc from coordinator's data
+            charging_data = coordinator.data.get("charging")
+            if not charging_data:
+                LOGGER.error(
+                    "No charging data available to set charging current limit."
+                )
+                return
+
+            chrg_mgmt_data = getattr(charging_data, "chrgMgmtData", None)
+            if not chrg_mgmt_data:
+                LOGGER.error(
+                    "No charging management data available to set charging current limit."
+                )
+                return
+
+            target_soc_value = getattr(chrg_mgmt_data, "bmsOnBdChrgTrgtSOCDspCmd", None)
+            if target_soc_value is None:
+                LOGGER.error(
+                    "Target SOC value is not available to set charging current limit."
+                )
+                return
+
+            # Map the target_soc_value to BatterySoc enum
+            target_soc_enum = {
+                1: BatterySoc.SOC_40,
+                2: BatterySoc.SOC_50,
+                3: BatterySoc.SOC_60,
+                4: BatterySoc.SOC_70,
+                5: BatterySoc.SOC_80,
+                6: BatterySoc.SOC_90,
+                7: BatterySoc.SOC_100,
+            }.get(target_soc_value, None)
+
+            if target_soc_enum is None:
+                LOGGER.error(f"Unknown target SOC value: {target_soc_value}")
+                raise ValueError(f"Unknown target SOC value: {target_soc_value}")
+
+            # Set the charging current limit with target_soc
+            await client.set_current_limit(vin, target_soc_enum, selected_code)
+            LOGGER.info(
+                "Charging current limit set to %s successfully for VIN: %s",
+                current_limit,
+                vin,
+            )
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Failed to set charging current limit for VIN %s: %s", vin, e)
+
+    async def handle_set_target_soc(call: ServiceCall) -> None:
+        """Handle the set_target_soc service call."""
+        vin = call.data["vin"]
+        target_soc = call.data["target_soc"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.TARGET_SOC, "set_target_soc"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.target_soc_long_interval
+
+            await client.set_target_soc(vin, target_soc)
+            LOGGER.info("%s Target SOC set for VIN: %s", target_soc, vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error setting target SOC for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.setting_target_soc", e)
+
+    async def handle_control_rear_window_heat(call: ServiceCall) -> None:
+        """Handle the control_rear_window_heat service call."""
+        vin = call.data["vin"]
+        action = call.data["action"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.REAR_WINDOW_HEAT, "control_rear_window_heat"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.rear_window_heat_long_interval
+
+            await client.control_rear_window_heat(vin, action)
+            LOGGER.info("Rear window heat %sed for VIN: %s", action, vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error controlling rear window heat for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_rear_window_heat", e)
+
+    async def handle_control_heated_seats(call: ServiceCall) -> None:
+        """Handle the control_heated_seats service call."""
+        vin = call.data["vin"]
+        left_level = call.data["left_level"]
+        right_level = call.data["right_level"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.HEATED_SEATS, "control_heated_seats"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.heated_seats_long_interval
+
+            await client.control_heated_seats(vin, left_level, right_level)
+            LOGGER.info(
+                "Heated seats set: Left = %d, Right = %d for VIN: %s",
+                left_level,
+                right_level,
+                vin,
+            )
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error controlling heated seats for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_heated_seats", e)
+
+    async def handle_start_front_defrost(call: ServiceCall) -> None:
+        """Handle the start_front_defrost service call."""
+        vin = call.data["vin"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.FRONT_DEFROST, "start_front_defrost"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.front_defrost_long_interval
+
+            await client.start_front_defrost(vin)
+            LOGGER.info("Front defrost started successfully for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error starting front defrost for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.starting_front_defrost", e)
+
+    async def handle_update_vehicle_data(call: ServiceCall) -> None:
+        """Handle the update_vehicle_data service call."""
+        vin = call.data["vin"]
+        try:
+            _, coordinator = _get_vehicle_resources(hass, vin)
+            await coordinator.async_request_refresh()
+            LOGGER.info("Data update triggered for VIN: %s", vin)
+        except Exception as e:
+            LOGGER.warning("Coordinator not found for VIN %s: %s", vin, e)
+
+    async def handle_control_sunroof(call: ServiceCall) -> None:
+        vin = call.data["vin"]
+        should_open = call.data["should_open"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.SUNROOF, "control_sunroof"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.sunroof_long_interval
+
+            await client.control_sunroof(vin, should_open)
+            LOGGER.info("Sunroof control action completed for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error controlling sunroof for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_sunroof", e)
+
+    async def handle_control_charging_port_lock(call: ServiceCall) -> None:
+        vin = call.data["vin"]
+        unlock = call.data["unlock"]
+        try:
+            client, coordinator = _get_vehicle_resources(hass, vin)
+            if not _backend_allows(client, vin, Feature.CHARGING_PORT_LOCK, "control_charging_port_lock"):
+                return
+            immediate_interval = coordinator.after_action_delay
+            long_interval = coordinator.charging_port_lock_long_interval
+
+            await client.control_charging_port_lock(vin, unlock)
+            LOGGER.info("Charging port lock control action completed for VIN: %s", vin)
+            await coordinator.schedule_action_refresh(
+                vin,
+                immediate_interval,
+                long_interval,
+            )
+        except Exception as e:
+            LOGGER.error("Error controlling charging port lock for VIN %s: %s", vin, e)
+            _record_command_error(hass, vin, "service.controlling_charging_port_lock", e)
+
+    # Register services
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CONTROL_CHARGING_PORT_LOCK,
+        handle_control_charging_port_lock,
+        schema=SERVICE_PORT_LOCK_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CONTROL_HEATED_SEATS,
+        handle_control_heated_seats,
+        schema=SERVICE_CONTROL_HEATED_SEAT_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CONTROL_REAR_WINDOW_HEAT,
+        handle_control_rear_window_heat,
+        schema=SERVICE_REAR_WINDOW_DEFROST_ACTION_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CONTROL_SUNROOF,
+        handle_control_sunroof,
+        schema=SERVICE_SUNROOF_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_LOCK_VEHICLE, handle_lock_vehicle, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_OPEN_TAILGATE, handle_open_tailgate, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_BATTERY_HEATING_SCHEDULE,
+        handle_set_battery_heating_schedule,
+        schema=SERVICE_SET_BATTERY_HEATING_SCHEDULE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_SCHEDULED_CHARGING,
+        handle_set_scheduled_charging,
+        schema=SERVICE_SET_SCHEDULED_CHARGING_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CHARGING_CURRENT_LIMIT,
+        handle_set_charging_current,
+        schema=SERVICE_SET_CHARGING_CURRENT_LIMIT_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_TARGET_SOC,
+        handle_set_target_soc,
+        schema=SERVICE_SET_TARGET_SOC_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_AC,
+        handle_start_ac,
+        schema=SERVICE_START_AC_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_CLIMATE,
+        handle_start_climate,
+        schema=SERVICE_START_CLIMATE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_BATTERY_HEATING,
+        handle_start_battery_heating,
+        schema=SERVICE_VIN_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_START_CHARGING, handle_start_charging, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_FRONT_DEFROST,
+        handle_start_front_defrost,
+        schema=SERVICE_VIN_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_STOP_AC, handle_stop_ac, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_STOP_BATTERY_HEATING,
+        handle_stop_battery_heating,
+        schema=SERVICE_VIN_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_STOP_CHARGING, handle_stop_charging, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_TRIGGER_ALARM, handle_trigger_alarm, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_UNLOCK_VEHICLE, handle_unlock_vehicle, schema=SERVICE_VIN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_VEHICLE_DATA,
+        handle_update_vehicle_data,
+        schema=SERVICE_VIN_SCHEMA,
+    )
+
+    LOGGER.info("Services registered for MG SAIC integration.")
+
+
+async def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload MG SAIC services."""
+    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_CHARGING_PORT_LOCK)
+    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_HEATED_SEATS)
+    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_REAR_WINDOW_HEAT)
+    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_SUNROOF)
+    hass.services.async_remove(DOMAIN, SERVICE_LOCK_VEHICLE)
+    hass.services.async_remove(DOMAIN, SERVICE_OPEN_TAILGATE)
+    hass.services.async_remove(DOMAIN, SERVICE_SET_CHARGING_CURRENT_LIMIT)
+    hass.services.async_remove(DOMAIN, SERVICE_SET_TARGET_SOC)
+    hass.services.async_remove(DOMAIN, SERVICE_START_AC)
+    hass.services.async_remove(DOMAIN, SERVICE_START_CLIMATE)
+    hass.services.async_remove(DOMAIN, SERVICE_START_BATTERY_HEATING)
+    hass.services.async_remove(DOMAIN, SERVICE_START_CHARGING)
+    hass.services.async_remove(DOMAIN, SERVICE_START_FRONT_DEFROST)
+    hass.services.async_remove(DOMAIN, SERVICE_STOP_AC)
+    hass.services.async_remove(DOMAIN, SERVICE_STOP_BATTERY_HEATING)
+    hass.services.async_remove(DOMAIN, SERVICE_STOP_CHARGING)
+    hass.services.async_remove(DOMAIN, SERVICE_TRIGGER_ALARM)
+    hass.services.async_remove(DOMAIN, SERVICE_UNLOCK_VEHICLE)
+    hass.services.async_remove(DOMAIN, SERVICE_UPDATE_VEHICLE_DATA)
+
+    LOGGER.info("Services unregistered for MG SAIC integration.")

--- a/custom_components/mg_saic/services.yaml
+++ b/custom_components/mg_saic/services.yaml
@@ -1,923 +1,304 @@
-# File: services.py
-
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import config_validation as cv
-from homeassistant.util import dt as dt_util
-import voluptuous as vol
-
-from .backends import Feature, backend_supports
-from .const import (
-    DOMAIN,
-    LOGGER,
-    ChargeCurrentLimitOption,
-    BatterySoc,
-)
-
-SERVICE_CONTROL_CHARGING_PORT_LOCK = "control_charging_port_lock"
-SERVICE_CONTROL_HEATED_SEATS = "control_heated_seats"
-SERVICE_CONTROL_REAR_WINDOW_HEAT = "control_rear_window_heat"
-SERVICE_CONTROL_SUNROOF = "control_sunroof"
-SERVICE_LOCK_VEHICLE = "lock_vehicle"
-SERVICE_UNLOCK_VEHICLE = "unlock_vehicle"
-SERVICE_START_AC = "start_ac"
-SERVICE_STOP_AC = "stop_ac"
-SERVICE_OPEN_TAILGATE = "open_tailgate"
-SERVICE_SET_BATTERY_HEATING_SCHEDULE = "set_battery_heating_schedule"
-SERVICE_SET_SCHEDULED_CHARGING = "set_scheduled_charging"
-SERVICE_SET_CHARGING_CURRENT_LIMIT = "set_charging_current_limit"
-SERVICE_SET_TARGET_SOC = "set_target_soc"
-SERVICE_START_CLIMATE = "start_climate"
-SERVICE_START_BATTERY_HEATING = "start_battery_heating"
-SERVICE_START_CHARGING = "start_charging"
-SERVICE_START_FRONT_DEFROST = "start_front_defrost"
-SERVICE_STOP_BATTERY_HEATING = "stop_battery_heating"
-SERVICE_STOP_CHARGING = "stop_charging"
-SERVICE_TRIGGER_ALARM = "trigger_alarm"
-SERVICE_UPDATE_VEHICLE_DATA = "update_vehicle_data"
-
-
-SERVICE_ACTION_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("action"): cv.boolean,
-    }
-)
-
-SERVICE_CONTROL_HEATED_SEAT_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("left_level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
-        vol.Required("right_level"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
-    }
-)
-
-SERVICE_PORT_LOCK_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("unlock"): cv.boolean,
-    }
-)
-
-SERVICE_REAR_WINDOW_DEFROST_ACTION_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("action"): vol.In(["start", "stop"]),
-    }
-)
-
-SERVICE_START_AC_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("temperature"): vol.Coerce(float),
-    }
-)
-
-SERVICE_START_CLIMATE_SCHEMA = None
-
-SERVICE_SET_CHARGING_CURRENT_LIMIT_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("current_limit"): vol.In(
-            [e.limit for e in ChargeCurrentLimitOption]
-        ),
-    }
-)
-
-SERVICE_SET_TARGET_SOC_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("target_soc"): vol.In([40, 50, 60, 70, 80, 90, 100]),
-    }
-)
-
-SERVICE_SET_BATTERY_HEATING_SCHEDULE_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("enable"): cv.boolean,
-        vol.Optional("start_time"): cv.time,
-    }
-)
-
-SERVICE_SET_SCHEDULED_CHARGING_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("mode"): vol.In(
-            ["disabled", "until_target_soc", "until_scheduled_time"]
-        ),
-        vol.Optional("start_time"): cv.time,
-        vol.Optional("end_time"): cv.time,
-    }
-)
-
-SERVICE_SUNROOF_SCHEMA = vol.Schema(
-    {
-        vol.Required("vin"): cv.string,
-        vol.Required("should_open"): cv.boolean,
-    }
-)
-
-SERVICE_VIN_SCHEMA = vol.Schema({vol.Required("vin"): cv.string})
-
-
-def _get_vehicle_resources(hass: HomeAssistant, vin: str):
-    """Resolve the client and coordinator for a VIN."""
-    domain_data = hass.data.get(DOMAIN, {})
-    client = domain_data.get("clients_by_vin", {}).get(vin)
-    coordinator = domain_data.get("coordinators_by_vin", {}).get(vin)
-
-    if client is None or coordinator is None:
-        raise ValueError(f"No integration resources found for VIN {vin}")
-
-    return client, coordinator
-
-
-def _record_command_error(hass: HomeAssistant, vin: str, source: str, error) -> None:
-    """Record a service-call command failure on the vehicle's coordinator.
-
-    Service handlers assign `coordinator` inside their try block, so it may be
-    unbound in the except block — this re-resolves it safely. Best-effort and
-    never raises, so it can't mask the original error.
-
-    This is what feeds the Vehicle Reachability sensor: without it, commands
-    issued via SERVICE CALLS never flagged a return-code-4 failure, so the
-    sensor stayed "awake" while commands were failing (see #238).
-    """
-    try:
-        _, coordinator = _get_vehicle_resources(hass, vin)
-        coordinator.record_command_error(source, error)
-    except Exception:  # noqa: BLE001 - supplementary, must never break the caller
-        pass
-
-
-def _backend_allows(client, vin: str, feature: Feature, service: str) -> bool:
-    """Return True if *vin*'s backend supports *feature*, else log and refuse.
-
-    Service calls can target any configured VIN, including vehicles on
-    backends that do not implement the requested command family (e.g. MG
-    India has no charging control — issue #169).  Refusing here, before any
-    client call, guarantees an unsupported command can never reach a real
-    car through the services layer.
-    """
-    if backend_supports(client, feature):
-        return True
-    LOGGER.error(
-        "Service %s is not supported for VIN %s: this vehicle's backend "
-        "(region) does not implement '%s'.",
-        service,
-        vin,
-        feature.value,
-    )
-    return False
-
-
-async def async_setup_services(hass: HomeAssistant) -> None:
-    """Set up services for the MG SAIC integration."""
-
-    # Dynamically define SERVICE_START_CLIMATE_SCHEMA based on vehicle's temperature limits
-    global SERVICE_START_CLIMATE_SCHEMA
-    SERVICE_START_CLIMATE_SCHEMA = vol.Schema(
-        {
-            vol.Required("vin"): cv.string,
-            vol.Required("temperature"): vol.Coerce(float),
-            vol.Required("fan_speed"): vol.Coerce(int),
-            vol.Optional("ac_on", default=True): cv.boolean,
-        }
-    )
-
-    async def handle_lock_vehicle(call: ServiceCall) -> None:
-        """Handle the lock_vehicle service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.LOCK, "lock_vehicle"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.lock_unlock_long_interval
-
-            await client.lock_vehicle(vin)
-            LOGGER.info("Vehicle locked successfully for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error locking vehicle for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.locking_vehicle", e)
-
-    async def handle_unlock_vehicle(call: ServiceCall) -> None:
-        """Handle the unlock_vehicle service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.LOCK, "unlock_vehicle"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.lock_unlock_long_interval
-
-            await client.unlock_vehicle(vin)
-            LOGGER.info("Vehicle unlocked successfully for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error unlocking vehicle for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.unlocking_vehicle", e)
-
-    async def handle_start_ac(call: ServiceCall) -> None:
-        """Handle the start_ac service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CLIMATE, "start_ac"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.ac_long_interval
-
-            # Retrieve desired temperature from service call
-            temperature = call.data.get("temperature")
-            if temperature is None:
-                LOGGER.error("No temperature provided for start_ac service.")
-                return
-
-            # Clamp the temperature within allowable range
-            clamped_temp = max(
-                coordinator.min_temp, min(coordinator.max_temp, temperature)
-            )
-
-            # Calculate temperature_idx using coordinator's method
-            temperature_idx = coordinator.get_ac_temperature_idx(clamped_temp)
-
-            # Call the start_ac method from api.py
-            await client.start_ac(
-                vin=vin,
-                temperature_idx=temperature_idx,
-            )
-            LOGGER.info(
-                "AC started successfully for VIN: %s with temperature index %d",
-                vin,
-                temperature_idx,
-            )
-
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error starting AC for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.starting_ac", e)
-
-    async def handle_stop_ac(call: ServiceCall) -> None:
-        """Handle the stop_ac service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CLIMATE, "stop_ac"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.ac_long_interval
-
-            await client.stop_ac(vin)
-            LOGGER.info("AC stopped successfully for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error stopping AC for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.stopping_ac", e)
-
-    async def handle_start_climate(call: ServiceCall) -> None:
-        """Handle the start_climate service call."""
-        vin = call.data["vin"]
-        temperature = call.data["temperature"]
-        fan_speed = call.data["fan_speed"]
-        ac_on = call.data["ac_on"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CLIMATE, "start_climate"):
-                return
-            min_temp = coordinator.min_temp
-            max_temp = coordinator.max_temp
-
-            # Clamp temperature within allowable range
-            clamped_temp = max(min_temp, min(max_temp, round(temperature)))
-
-            # Calculate temperature_idx using coordinator's method
-            temperature_idx = coordinator.get_ac_temperature_idx(clamped_temp)
-
-            # Clamp fan speed within allowable range
-            fan_speed = max(1, min(5, fan_speed))
-
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.ac_long_interval
-
-            await client.start_climate(
-                vin=vin,
-                temperature_idx=temperature_idx,
-                fan_speed=fan_speed,
-                ac_on=ac_on,
-            )
-
-            LOGGER.info(
-                "Climate started with AC ON: %s, temperature %s°C and fan speed %s for VIN: %s",
-                ac_on,
-                temperature,
-                fan_speed,
-                vin,
-            )
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error starting AC with settings for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.starting_ac_with_settings", e)
-
-    async def handle_open_tailgate(call: ServiceCall) -> None:
-        """Handle the open_tailgate service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.TAILGATE, "open_tailgate"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.tailgate_long_interval
-
-            await client.open_tailgate(vin)
-            LOGGER.info("Tailgate opened successfully for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error opening tailgate for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.opening_tailgate", e)
-
-    async def handle_trigger_alarm(call: ServiceCall) -> None:
-        """Handle the trigger_alarm service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.FIND_MY_CAR, "trigger_alarm"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.alarm_long_interval
-            await client.trigger_alarm(vin)
-            LOGGER.info("Alarm triggered successfully for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error triggering alarm for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.triggering_alarm", e)
-
-    async def handle_start_charging(call: ServiceCall) -> None:
-        """Handle the start_charging service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CHARGING_CONTROL, "start_charging"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.charging_long_interval
-
-            LOGGER.debug(f"Sending start charging command for VIN: {vin}")
-            await client.send_vehicle_charging_control(vin, "start")
-            LOGGER.info(f"Charging started successfully for VIN: {vin}")
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error(f"Error starting charging for VIN {vin}: {e}")
-
-    async def handle_stop_charging(call: ServiceCall) -> None:
-        """Handle the stop_charging service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CHARGING_CONTROL, "stop_charging"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.charging_long_interval
-
-            LOGGER.debug(f"Sending stop charging command for VIN: {vin}")
-            await client.send_vehicle_charging_control(vin, "stop")
-            LOGGER.info(f"Charging stopped successfully for VIN: {vin}")
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error(f"Error stopping charging for VIN {vin}: {e}")
-
-    async def handle_start_battery_heating(call: ServiceCall) -> None:
-        """Handle the start_battery_heating service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.BATTERY_HEATING, "start_battery_heating"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.battery_heating_long_interval
-
-            LOGGER.debug(f"Sending start battery heating command for VIN: {vin}")
-            await client.send_vehicle_charging_ptc_heat(vin, "start")
-            LOGGER.info(f"Battery heating started successfully for VIN: {vin}")
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error(f"Error starting battery heating for VIN {vin}: {e}")
-
-    async def handle_stop_battery_heating(call: ServiceCall) -> None:
-        """Handle the stop_battery_heating service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.BATTERY_HEATING, "stop_battery_heating"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.battery_heating_long_interval
-
-            LOGGER.debug(f"Sending stop battery heating command for VIN: {vin}")
-            await client.send_vehicle_charging_ptc_heat(vin, "stop")
-            LOGGER.info(f"Battery heating stopped successfully for VIN: {vin}")
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error(f"Error stopping battery heating for VIN {vin}: {e}")
-
-    async def handle_set_battery_heating_schedule(call: ServiceCall) -> None:
-        """Handle the set_battery_heating_schedule service call."""
-        vin = call.data["vin"]
-        enable = call.data["enable"]
-        start_time = call.data.get("start_time")
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.BATTERY_HEATING, "set_battery_heating_schedule"):
-                return
-
-            if enable:
-                tz = dt_util.get_default_time_zone()
-                if start_time is None:
-                    # Fall back to the pending value from the time entity,
-                    # then the schedule last reported by the vehicle.
-                    start_time = coordinator.battery_heating_pending_time
-                    if start_time is None:
-                        schedule = coordinator.data.get("battery_heating_schedule")
-                        if schedule is not None and getattr(schedule, "startTime", 0):
-                            start_time = schedule.decode_start_time(tz)
-                if start_time is None:
-                    LOGGER.error(
-                        "Cannot enable battery heating schedule for VIN %s: "
-                        "no start_time provided and no previous schedule known.",
-                        vin,
-                    )
-                    return
-                coordinator.battery_heating_pending_time = start_time
-                LOGGER.debug(
-                    "Enabling battery heating schedule for VIN %s at %s",
-                    vin,
-                    start_time,
-                )
-                await client.enable_battery_heating_schedule(vin, start_time, tz)
-                LOGGER.info(
-                    "Battery heating schedule enabled at %s for VIN: %s",
-                    start_time,
-                    vin,
-                )
-            else:
-                LOGGER.debug("Disabling battery heating schedule for VIN %s", vin)
-                await client.disable_battery_heating_schedule(vin)
-                LOGGER.info("Battery heating schedule disabled for VIN: %s", vin)
-
-            await coordinator.async_request_refresh()
-        except Exception as e:
-            LOGGER.error(
-                "Error setting battery heating schedule for VIN %s: %s", vin, e
-            )
-
-    async def handle_set_scheduled_charging(call: ServiceCall) -> None:
-        """Handle the set_scheduled_charging service call."""
-        from saic_ismart_client_ng.api.vehicle_charging import ScheduledChargingMode
-
-        from .time import (
-            DEFAULT_SCHEDULED_CHARGING_END,
-            DEFAULT_SCHEDULED_CHARGING_START,
-            decode_scheduled_charging_field,
-        )
-
-        vin = call.data["vin"]
-        mode_key = call.data["mode"]
-        mode = {
-            "disabled": ScheduledChargingMode.DISABLED,
-            "until_target_soc": ScheduledChargingMode.UNTIL_CONFIGURED_SOC,
-            "until_scheduled_time": ScheduledChargingMode.UNTIL_CONFIGURED_TIME,
-        }[mode_key]
-
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.SCHEDULED_CHARGING, "set_scheduled_charging"):
-                return
-
-            charging_data = coordinator.data.get("charging")
-            chrg_mgmt_data = getattr(charging_data, "chrgMgmtData", None)
-
-            start_time = call.data.get("start_time")
-            if start_time is None:
-                start_time = coordinator.scheduled_charging_pending_start
-            if start_time is None:
-                start_time = decode_scheduled_charging_field(
-                    chrg_mgmt_data, "bmsReserStHourDspCmd", "bmsReserStMintueDspCmd"
-                )
-            if start_time is None:
-                start_time = DEFAULT_SCHEDULED_CHARGING_START
-
-            end_time = call.data.get("end_time")
-            if end_time is None:
-                end_time = coordinator.scheduled_charging_pending_end
-            if end_time is None:
-                end_time = decode_scheduled_charging_field(
-                    chrg_mgmt_data, "bmsReserSpHourDspCmd", "bmsReserSpMintueDspCmd"
-                )
-            if end_time is None:
-                end_time = DEFAULT_SCHEDULED_CHARGING_END
-
-            # Keep the time entities in sync with what was sent.
-            coordinator.scheduled_charging_pending_start = start_time
-            coordinator.scheduled_charging_pending_end = end_time
-
-            await client.set_scheduled_charging(vin, start_time, end_time, mode)
-            LOGGER.info(
-                "Scheduled charging set to %s (%s - %s) for VIN: %s",
-                mode_key,
-                start_time,
-                end_time,
-                vin,
-            )
-            await coordinator.async_request_refresh()
-        except Exception as e:
-            LOGGER.error("Error setting scheduled charging for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.setting_scheduled_charging", e)
-
-    async def handle_set_charging_current(call: ServiceCall):
-        """Handle the service call to set charging current."""
-        vin = call.data["vin"]
-        current_limit = call.data["current_limit"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CURRENT_LIMIT, "set_charging_current"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.charging_current_long_interval
-
-            # Map the string option to the local enum
-            selected_code = ChargeCurrentLimitOption.to_code(current_limit)
-
-            # Get the current target_soc from coordinator's data
-            charging_data = coordinator.data.get("charging")
-            if not charging_data:
-                LOGGER.error(
-                    "No charging data available to set charging current limit."
-                )
-                return
-
-            chrg_mgmt_data = getattr(charging_data, "chrgMgmtData", None)
-            if not chrg_mgmt_data:
-                LOGGER.error(
-                    "No charging management data available to set charging current limit."
-                )
-                return
-
-            target_soc_value = getattr(chrg_mgmt_data, "bmsOnBdChrgTrgtSOCDspCmd", None)
-            if target_soc_value is None:
-                LOGGER.error(
-                    "Target SOC value is not available to set charging current limit."
-                )
-                return
-
-            # Map the target_soc_value to BatterySoc enum
-            target_soc_enum = {
-                1: BatterySoc.SOC_40,
-                2: BatterySoc.SOC_50,
-                3: BatterySoc.SOC_60,
-                4: BatterySoc.SOC_70,
-                5: BatterySoc.SOC_80,
-                6: BatterySoc.SOC_90,
-                7: BatterySoc.SOC_100,
-            }.get(target_soc_value, None)
-
-            if target_soc_enum is None:
-                LOGGER.error(f"Unknown target SOC value: {target_soc_value}")
-                raise ValueError(f"Unknown target SOC value: {target_soc_value}")
-
-            # Set the charging current limit with target_soc
-            await client.set_current_limit(vin, target_soc_enum, selected_code)
-            LOGGER.info(
-                "Charging current limit set to %s successfully for VIN: %s",
-                current_limit,
-                vin,
-            )
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Failed to set charging current limit for VIN %s: %s", vin, e)
-
-    async def handle_set_target_soc(call: ServiceCall) -> None:
-        """Handle the set_target_soc service call."""
-        vin = call.data["vin"]
-        target_soc = call.data["target_soc"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.TARGET_SOC, "set_target_soc"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.target_soc_long_interval
-
-            await client.set_target_soc(vin, target_soc)
-            LOGGER.info("%s Target SOC set for VIN: %s", target_soc, vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error setting target SOC for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.setting_target_soc", e)
-
-    async def handle_control_rear_window_heat(call: ServiceCall) -> None:
-        """Handle the control_rear_window_heat service call."""
-        vin = call.data["vin"]
-        action = call.data["action"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.REAR_WINDOW_HEAT, "control_rear_window_heat"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.rear_window_heat_long_interval
-
-            await client.control_rear_window_heat(vin, action)
-            LOGGER.info("Rear window heat %sed for VIN: %s", action, vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error controlling rear window heat for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.controlling_rear_window_heat", e)
-
-    async def handle_control_heated_seats(call: ServiceCall) -> None:
-        """Handle the control_heated_seats service call."""
-        vin = call.data["vin"]
-        left_level = call.data["left_level"]
-        right_level = call.data["right_level"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.HEATED_SEATS, "control_heated_seats"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.heated_seats_long_interval
-
-            await client.control_heated_seats(vin, left_level, right_level)
-            LOGGER.info(
-                "Heated seats set: Left = %d, Right = %d for VIN: %s",
-                left_level,
-                right_level,
-                vin,
-            )
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error controlling heated seats for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.controlling_heated_seats", e)
-
-    async def handle_start_front_defrost(call: ServiceCall) -> None:
-        """Handle the start_front_defrost service call."""
-        vin = call.data["vin"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.FRONT_DEFROST, "start_front_defrost"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.front_defrost_long_interval
-
-            await client.start_front_defrost(vin)
-            LOGGER.info("Front defrost started successfully for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error starting front defrost for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.starting_front_defrost", e)
-
-    async def handle_update_vehicle_data(call: ServiceCall) -> None:
-        """Handle the update_vehicle_data service call."""
-        vin = call.data["vin"]
-        try:
-            _, coordinator = _get_vehicle_resources(hass, vin)
-            await coordinator.async_request_refresh()
-            LOGGER.info("Data update triggered for VIN: %s", vin)
-        except Exception as e:
-            LOGGER.warning("Coordinator not found for VIN %s: %s", vin, e)
-
-    async def handle_control_sunroof(call: ServiceCall) -> None:
-        vin = call.data["vin"]
-        should_open = call.data["should_open"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.SUNROOF, "control_sunroof"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.sunroof_long_interval
-
-            await client.control_sunroof(vin, should_open)
-            LOGGER.info("Sunroof control action completed for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error controlling sunroof for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.controlling_sunroof", e)
-
-    async def handle_control_charging_port_lock(call: ServiceCall) -> None:
-        vin = call.data["vin"]
-        unlock = call.data["unlock"]
-        try:
-            client, coordinator = _get_vehicle_resources(hass, vin)
-            if not _backend_allows(client, vin, Feature.CHARGING_PORT_LOCK, "control_charging_port_lock"):
-                return
-            immediate_interval = coordinator.after_action_delay
-            long_interval = coordinator.charging_port_lock_long_interval
-
-            await client.control_charging_port_lock(vin, unlock)
-            LOGGER.info("Charging port lock control action completed for VIN: %s", vin)
-            await coordinator.schedule_action_refresh(
-                vin,
-                immediate_interval,
-                long_interval,
-            )
-        except Exception as e:
-            LOGGER.error("Error controlling charging port lock for VIN %s: %s", vin, e)
-            _record_command_error(hass, vin, "service.controlling_charging_port_lock", e)
-
-    # Register services
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CONTROL_CHARGING_PORT_LOCK,
-        handle_control_charging_port_lock,
-        schema=SERVICE_PORT_LOCK_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CONTROL_HEATED_SEATS,
-        handle_control_heated_seats,
-        schema=SERVICE_CONTROL_HEATED_SEAT_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CONTROL_REAR_WINDOW_HEAT,
-        handle_control_rear_window_heat,
-        schema=SERVICE_REAR_WINDOW_DEFROST_ACTION_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CONTROL_SUNROOF,
-        handle_control_sunroof,
-        schema=SERVICE_SUNROOF_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_LOCK_VEHICLE, handle_lock_vehicle, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_OPEN_TAILGATE, handle_open_tailgate, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_BATTERY_HEATING_SCHEDULE,
-        handle_set_battery_heating_schedule,
-        schema=SERVICE_SET_BATTERY_HEATING_SCHEDULE_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_SCHEDULED_CHARGING,
-        handle_set_scheduled_charging,
-        schema=SERVICE_SET_SCHEDULED_CHARGING_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_CHARGING_CURRENT_LIMIT,
-        handle_set_charging_current,
-        schema=SERVICE_SET_CHARGING_CURRENT_LIMIT_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_TARGET_SOC,
-        handle_set_target_soc,
-        schema=SERVICE_SET_TARGET_SOC_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_START_AC,
-        handle_start_ac,
-        schema=SERVICE_START_AC_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_START_CLIMATE,
-        handle_start_climate,
-        schema=SERVICE_START_CLIMATE_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_START_BATTERY_HEATING,
-        handle_start_battery_heating,
-        schema=SERVICE_VIN_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_START_CHARGING, handle_start_charging, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_START_FRONT_DEFROST,
-        handle_start_front_defrost,
-        schema=SERVICE_VIN_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_STOP_AC, handle_stop_ac, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_STOP_BATTERY_HEATING,
-        handle_stop_battery_heating,
-        schema=SERVICE_VIN_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_STOP_CHARGING, handle_stop_charging, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_TRIGGER_ALARM, handle_trigger_alarm, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_UNLOCK_VEHICLE, handle_unlock_vehicle, schema=SERVICE_VIN_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_UPDATE_VEHICLE_DATA,
-        handle_update_vehicle_data,
-        schema=SERVICE_VIN_SCHEMA,
-    )
-
-    LOGGER.info("Services registered for MG SAIC integration.")
-
-
-async def async_unload_services(hass: HomeAssistant) -> None:
-    """Unload MG SAIC services."""
-    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_CHARGING_PORT_LOCK)
-    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_HEATED_SEATS)
-    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_REAR_WINDOW_HEAT)
-    hass.services.async_remove(DOMAIN, SERVICE_CONTROL_SUNROOF)
-    hass.services.async_remove(DOMAIN, SERVICE_LOCK_VEHICLE)
-    hass.services.async_remove(DOMAIN, SERVICE_OPEN_TAILGATE)
-    hass.services.async_remove(DOMAIN, SERVICE_SET_CHARGING_CURRENT_LIMIT)
-    hass.services.async_remove(DOMAIN, SERVICE_SET_TARGET_SOC)
-    hass.services.async_remove(DOMAIN, SERVICE_START_AC)
-    hass.services.async_remove(DOMAIN, SERVICE_START_CLIMATE)
-    hass.services.async_remove(DOMAIN, SERVICE_START_BATTERY_HEATING)
-    hass.services.async_remove(DOMAIN, SERVICE_START_CHARGING)
-    hass.services.async_remove(DOMAIN, SERVICE_START_FRONT_DEFROST)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_AC)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_BATTERY_HEATING)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_CHARGING)
-    hass.services.async_remove(DOMAIN, SERVICE_TRIGGER_ALARM)
-    hass.services.async_remove(DOMAIN, SERVICE_UNLOCK_VEHICLE)
-    hass.services.async_remove(DOMAIN, SERVICE_UPDATE_VEHICLE_DATA)
-
-    LOGGER.info("Services unregistered for MG SAIC integration.")
+control_charging_port_lock:
+  description: "Control the charging port lock (lock/unlock)."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    unlock:
+      description: "True to unlock charging port, false to lock."
+      example: true
+      selector:
+        boolean: {}
+
+control_heated_seats:
+  description: "Control the heated seat levels for both front seats."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    left_level:
+      description: "Heating level for the left seat (0 = Off, 1 = Low, 2 = Medium, 3 = High)."
+      example: 2
+      selector:
+        select:
+          options:
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+    right_level:
+      description: "Heating level for the right seat (0 = Off, 1 = Low, 2 = Medium, 3 = High)."
+      example: 3
+      selector:
+        select:
+          options:
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+
+
+control_rear_window_heat:
+  description: "Control the rear window heat."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    action:
+      description: "Action to perform."
+      example: "start"
+      selector:
+        select:
+          options:
+            - "start"
+            - "stop"
+
+control_sunroof:
+  description: "Control the sunroof (open or close)."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    should_open:
+      description: "True to open the sunroof, false to close."
+      example: true
+      selector:
+        boolean: {}
+
+lock_vehicle:
+  description: "Lock the vehicle."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+open_tailgate:
+  description: "Open the vehicle's tailgate."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+set_battery_heating_schedule:
+  description: "Enable or disable the scheduled (timed) battery heating."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    enable:
+      description: "True to enable the schedule, false to disable it."
+      example: true
+      selector:
+        boolean: {}
+    start_time:
+      description: "Daily start time for battery heating (in your Home Assistant timezone). Required when enabling unless a schedule was previously set."
+      example: "06:30:00"
+      selector:
+        time: {}
+
+set_scheduled_charging:
+  description: "Set the scheduled charging window and mode."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    mode:
+      description: "Charging schedule mode."
+      example: "until_target_soc"
+      selector:
+        select:
+          options:
+            - "disabled"
+            - "until_target_soc"
+            - "until_scheduled_time"
+    start_time:
+      description: "Charging window start time (as shown in the iSmart app). Optional — falls back to the Scheduled Charging Start entity, then the value last reported by the vehicle."
+      example: "00:30:00"
+      selector:
+        time: {}
+    end_time:
+      description: "Charging window end time (as shown in the iSmart app). Optional — falls back to the Scheduled Charging End entity, then the value last reported by the vehicle."
+      example: "05:30:00"
+      selector:
+        time: {}
+
+set_charging_current_limit:
+  description: "Set the charging current limit for the vehicle."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    current_limit:
+      description: "Select the desired charging current limit."
+      example: "16A"
+      selector:
+        select:
+          options:
+            - "0 (Ignore)"
+            - "6A"
+            - "8A"
+            - "16A"
+            - "Max"
+
+set_target_soc:
+  description: "Set the target SOC (State of Charge) for the vehicle."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    target_soc:
+      description: "Desired target SOC percentage (10-100)."
+      example: 80
+      selector:
+        number:
+          min: 10
+          max: 100
+          step: 1
+
+start_ac:
+  description: "Start the vehicle's AC system."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    temperature:
+      description: "Desired temperature in degrees Celsius."
+      example: 22.0
+      selector:
+        number:
+          min: 16
+          max: 30
+          step: 1
+
+start_climate:
+  description: "Start the vehicle's Climate system with temperature and fan settings."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+    temperature:
+      description: "Desired temperature in degrees Celsius."
+      example: 22.0
+      selector:
+        number:
+          min: 16
+          max: 30
+          step: 1
+    fan_speed:
+      description: "Fan speed level (e.g., 1-5)."
+      example: 3
+      selector:
+        number:
+          min: 1
+          max: 5
+          step: 1
+    ac_on:
+      description: "Turn AC on or off (true = AC ON, false = AC OFF)."
+      example: true
+      selector:
+        boolean: {}
+
+start_battery_heating:
+  description: "Start the vehicle battery heating process."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+start_charging:
+  description: "Start the vehicle charging process."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+start_front_defrost:
+  description: "Start the front defrost system of the vehicle."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+stop_ac:
+  description: "Stop the vehicle's AC system."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+stop_battery_heating:
+  description: "Stop the vehicle battery heating process."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+stop_charging:
+  description: "Stop the vehicle charging process."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+trigger_alarm:
+  description: "Trigger the vehicle's alarm."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+unlock_vehicle:
+  description: "Unlock the vehicle."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}
+
+update_vehicle_data:
+  description: "Manually trigger a data update from the vehicle."
+  fields:
+    vin:
+      description: "Vehicle Identification Number."
+      example: "1HGCM82633A123456"
+      selector:
+        text: {}

--- a/custom_components/mg_saic/switch.py
+++ b/custom_components/mg_saic/switch.py
@@ -1,6 +1,7 @@
 # File: switch.py
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from .api import CommandsLimitReachedException
@@ -136,6 +137,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         else:
             LOGGER.debug(f"Battery heating switch not created for VIN {vin}.")
+
+    # Holiday mode switch — always available; it only changes polling cadence,
+    # so it is backend-agnostic (works for both global and India accounts).
+    switches.append(SAICMGHolidayModeSwitch(coordinator, entry, vin_info, vin))
 
     async_add_entities(switches)
 
@@ -857,3 +862,52 @@ class SAICMGSunroofSwitch(CoordinatorEntity, SwitchEntity):
         except Exception as e:
             LOGGER.error("Error closing sunroof for VIN %s: %s", self._vin, e)
             self.coordinator.record_command_error("Error closing sunroof", e)
+
+
+class SAICMGHolidayModeSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to enable/disable holiday mode (slow-polling override).
+
+    Turning this on overrides the idle polling cadence with a much longer
+    interval (default 12h, configurable) to minimise telematics wake-ups and,
+    on PHEVs, reduce 12V parasitic drain while the car is left for a long time.
+    It does NOT slow polling while the car is charging or powered on (those are
+    deliberate — the user still wants updates then), and it does not modify the
+    user's configured intervals — it is a runtime override only, persisted so it
+    survives a restart. Toggle it off to return to normal polling.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator, entry, vin_info, vin):
+        """Initialize the holiday mode switch."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_name = f"{vin_info.brandName} {vin_info.modelName} Holiday Mode"
+        self._attr_unique_id = f"{entry.entry_id}_{vin}_holiday_mode"
+        self._attr_icon = "mdi:palm-tree"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return self._device_info
+
+    @property
+    def is_on(self):
+        """Return true if holiday mode is enabled."""
+        return bool(getattr(self.coordinator, "holiday_mode", False))
+
+    @property
+    def available(self):
+        """Holiday mode is a local setting — available whenever the entry is."""
+        return True
+
+    async def async_turn_on(self, **kwargs):
+        """Enable holiday mode."""
+        await self.coordinator.async_set_holiday_mode(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Disable holiday mode."""
+        await self.coordinator.async_set_holiday_mode(False)
+        self.async_write_ha_state()

--- a/custom_components/mg_saic/switch.py
+++ b/custom_components/mg_saic/switch.py
@@ -517,8 +517,25 @@ class SAICMGFrontDefrostSwitch(CoordinatorEntity, SwitchEntity):
         return False
 
     async def async_turn_on(self, **kwargs):
-        """Start front defrost."""
+        """Start front defrost.
+
+        The vehicle will not start front defrost while the AC is already
+        running — the iSmart app blocks this client-side ("To turn on front
+        defrost, please turn off AC Auto mode"), so we mirror that guard rather
+        than sending a command the car ignores while still burning one of the
+        vehicle's limited remote commands.
+
+        The command itself always runs at a fixed 22°C: the library's
+        start_front_defrost() sends fan_speed=5, temperature_idx=8, which is
+        byte-identical to what the iSmart app sends.
+        """
         try:
+            if self.coordinator.is_climate_blocking_defrost():
+                await self.coordinator.notify_front_defrost_blocked(
+                    self._vin, "switch.front_defrost.turn_on"
+                )
+                return
+
             immediate_interval = self.coordinator.after_action_delay
             long_interval = self.coordinator.front_defrost_long_interval
 

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -353,6 +353,8 @@
           "has_rear_heated_seats": "Has Rear Heated Seats",
           "has_battery_heating": "Has Battery Heating",
           "update_interval": "Update Interval (in minutes)",
+          "holiday_update_interval": "Holiday mode idle interval (hours)",
+          "stale_data_threshold_hours": "Data staleness threshold (hours)",
           "charging_update_interval": "AC Charging Update Interval (in minutes)",
           "dc_charging_update_interval": "DC Charging Update Interval (in minutes)",
           "powered_update_interval": "Vehicle Powered On Update Interval (in minutes)",

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -382,5 +382,16 @@
         "title": "MG/SAIC Options"
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "vehicle_reachability": {
+        "state": {
+          "awake": "Awake",
+          "likely_asleep": "Likely asleep",
+          "unreachable": "Unreachable"
+        }
+      }
+    }
   }
 }

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -352,6 +352,8 @@
           "has_rear_heated_seats": "Tiene asientos traseros calefactables",
           "has_battery_heating": "Tiene Calefacción de Batería",
           "update_interval": "Intervalo de Actualización (en minutos)",
+          "holiday_update_interval": "Intervalo en modo vacaciones (horas)",
+          "stale_data_threshold_hours": "Umbral de datos obsoletos (horas)",
           "charging_update_interval": "Intervalo de Actualización durante la Carga AC (en minutos)",
           "dc_charging_update_interval": "Intervalo de Actualización durante la Carga DC (en minutos)",
           "powered_update_interval": "Intervalo de Actualización cuando el Vehículo Está Encendido (en minutos)",

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -381,5 +381,16 @@
         "title": "Opciones de MG/SAIC"
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "vehicle_reachability": {
+        "state": {
+          "awake": "Despierto",
+          "likely_asleep": "Probablemente dormido",
+          "unreachable": "Inaccesible"
+        }
+      }
+    }
   }
 }

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -382,5 +382,16 @@
         "title": "Options MG/SAIC"
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "vehicle_reachability": {
+        "state": {
+          "awake": "Réveillé",
+          "likely_asleep": "Probablement en veille",
+          "unreachable": "Injoignable"
+        }
+      }
+    }
   }
 }

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -353,6 +353,8 @@
           "has_rear_heated_seats": "Sièges arrière chauffants",
           "has_battery_heating": "Possède le chauffage de la batterie",
           "update_interval": "Intervalle de mise à jour (en minutes)",
+          "holiday_update_interval": "Intervalle en mode vacances (heures)",
+          "stale_data_threshold_hours": "Seuil de données obsolètes (heures)",
           "charging_update_interval": "Intervalle de mise à jour de la charge AC (en minutes)",
           "dc_charging_update_interval": "Intervalle de mise à jour de la charge DC (en minutes)",
           "powered_update_interval": "Intervalle de mise à jour lorsque le véhicule est allumé (en minutes)",

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -382,5 +382,16 @@
         "title": "Opções MG/SAIC"
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "vehicle_reachability": {
+        "state": {
+          "awake": "Acordado",
+          "likely_asleep": "Provavelmente adormecido",
+          "unreachable": "Inacessível"
+        }
+      }
+    }
   }
 }

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -353,6 +353,8 @@
           "has_rear_heated_seats": "Tem bancos traseiros aquecidos",
           "has_battery_heating": "Tem Aquecimento de Bateria",
           "update_interval": "Intervalo de Atualização (em minutos)",
+          "holiday_update_interval": "Intervalo do modo de férias (horas)",
+          "stale_data_threshold_hours": "Limite de dados desatualizados (horas)",
           "charging_update_interval": "Intervalo de Atualização de Carregamento AC (em minutos)",
           "dc_charging_update_interval": "Intervalo de Atualização de Carregamento DC (em minutos)",
           "powered_update_interval": "Intervalo de Atualização com Veículo Ligado (em minutos)",

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 import unittest
 
 
@@ -31,6 +32,39 @@ class NormalizeSunroofActionTests(unittest.TestCase):
     def test_rejects_invalid_value(self):
         with self.assertRaises(ValueError):
             LOGIC.normalize_sunroof_action("tilt")
+
+
+class BuildVehicleOptionsTests(unittest.TestCase):
+    def test_uses_model_name_and_masks_vin_in_label(self):
+        vin = "LSJW74096NZ123456"
+        vehicle = SimpleNamespace(vin=vin, modelName="New ZS", series="ZS")
+
+        options = LOGIC.build_vehicle_options([vehicle])
+
+        self.assertEqual(options, {vin: "New ZS (…23456)"})
+
+    def test_uses_series_when_model_name_is_missing(self):
+        vin = "LSJW74096NZ654321"
+        vehicle = SimpleNamespace(vin=vin, modelName="", series="E230")
+
+        options = LOGIC.build_vehicle_options([vehicle])
+
+        self.assertEqual(options, {vin: "E230 (…54321)"})
+
+    def test_falls_back_to_vin_without_model_metadata(self):
+        vin = "LSJW74096NZ111111"
+        vehicle = SimpleNamespace(vin=vin, modelName="", series="")
+
+        options = LOGIC.build_vehicle_options([vehicle])
+
+        self.assertEqual(options, {vin: vin})
+
+    def test_accepts_plain_vin_strings(self):
+        vin = "LSJW74096NZ222222"
+
+        options = LOGIC.build_vehicle_options([vin])
+
+        self.assertEqual(options, {vin: vin})
 
 
 class SelectUpdateIntervalTests(unittest.TestCase):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,129 @@
+"""Unit tests for config-entry setup failure handling."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+PACKAGE_NAME = "mg_saic_setup_under_test"
+
+
+class ConfigEntryNotReady(Exception):
+    """Test replacement for Home Assistant's retryable setup exception."""
+
+
+class LoginError(Exception):
+    """Distinct backend error used to verify exception chaining."""
+
+
+class FailingClient:
+    def __init__(self):
+        self.closed = False
+
+    async def login(self):
+        raise LoginError("temporary login failure")
+
+    async def close(self):
+        self.closed = True
+
+
+def _module(name, **attributes):
+    """Register a small module stub with the supplied attributes."""
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load_integration_module(client):
+    """Load mg_saic.__init__ with only its runtime imports stubbed."""
+    homeassistant = _module("homeassistant")
+    homeassistant.__path__ = []
+    _module(
+        "homeassistant.config_entries",
+        ConfigEntry=object,
+        ConfigEntryNotReady=ConfigEntryNotReady,
+    )
+    _module("homeassistant.core", HomeAssistant=object)
+
+    package = ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(PKG_DIR)]
+    sys.modules[PACKAGE_NAME] = package
+
+    feature = SimpleNamespace(ALARM_MESSAGES="alarm_messages")
+    _module(
+        f"{PACKAGE_NAME}.backends",
+        Feature=feature,
+        backend_supports=lambda *_args: False,
+        create_backend=lambda _data: client,
+    )
+    _module(
+        f"{PACKAGE_NAME}.coordinator",
+        SAICMGDataUpdateCoordinator=MagicMock(),
+    )
+    _module(
+        f"{PACKAGE_NAME}.message_poller",
+        SAICMGAccountPoller=MagicMock(),
+    )
+    _module(
+        f"{PACKAGE_NAME}.const",
+        DOMAIN="mg_saic",
+        LOGGER=MagicMock(),
+        PLATFORMS=(),
+    )
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    _module(
+        f"{PACKAGE_NAME}.services",
+        async_setup_services=_noop,
+        async_unload_services=_noop,
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        PACKAGE_NAME,
+        PKG_DIR / "__init__.py",
+        submodule_search_locations=[str(PKG_DIR)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[PACKAGE_NAME] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class SetupLoginFailureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_failed_login_is_closed_and_raised_as_retryable(self):
+        client = FailingClient()
+        integration = _load_integration_module(client)
+        hass = SimpleNamespace(data={})
+        entry = SimpleNamespace(
+            entry_id="entry-1",
+            data={
+                "username": "test@example.invalid",
+                "region": "India",
+                "vin": "TESTVIN1234567890",
+            },
+        )
+
+        with self.assertRaises(ConfigEntryNotReady) as context:
+            await integration.async_setup_entry(hass, entry)
+
+        self.assertIsInstance(context.exception.__cause__, LoginError)
+        self.assertTrue(client.closed)
+        account_key = (entry.data["username"], entry.data["region"])
+        self.assertNotIn(
+            account_key,
+            hass.data["mg_saic"]["account_clients"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -144,10 +144,8 @@ _load("mg_saic.utils", PKG_DIR / "utils.py")
 _load("mg_saic.coordinator", PKG_DIR / "coordinator.py", force=True)
 _load("mg_saic.message_poller", PKG_DIR / "message_poller.py", force=True)
 _load("mg_saic.services", PKG_DIR / "services.py", force=True)
-SETUP = _load("mg_saic.setup_module", PKG_DIR / "__init__.py")
 CF = _load("mg_saic.config_flow", PKG_DIR / "config_flow.py", force=True)
 
-DOMAIN = sys.modules["mg_saic.const"].DOMAIN
 
 
 def _run(coro):
@@ -158,60 +156,6 @@ def _run(coro):
         loop.close()
 
 
-class _FakeHass:
-    def __init__(self):
-        self.data = {}
-
-
-class _FakeEntry:
-    def __init__(self, data):
-        self.data = data
-        self.entry_id = "test_entry"
-        self.options = {}
-
-
-class _FailingBackend:
-    """Backend whose login always fails; records whether close() ran."""
-
-    def __init__(self):
-        self.closed = False
-
-    async def login(self):
-        raise RuntimeError("bad credentials")
-
-    async def close(self):
-        self.closed = True
-
-
-class TestLoginFailurePath(unittest.TestCase):
-    """Issue #230: login failure must raise ConfigEntryNotReady cleanly."""
-
-    def test_login_failure_raises_not_ready_and_cleans_up(self):
-        hass = _FakeHass()
-        entry = _FakeEntry(
-            {
-                "username": "user@example.com",
-                "password": "wrong",
-                "region": "EU",
-                "vin": "TESTVIN123",
-            }
-        )
-        backend = _FailingBackend()
-        original = SETUP.create_backend
-        SETUP.create_backend = lambda data: backend
-        try:
-            with self.assertRaises(_ConfigEntryNotReady) as ctx:
-                _run(SETUP.async_setup_entry(hass, entry))
-        finally:
-            SETUP.create_backend = original
-
-        # No secondary KeyError; the original cause is chained and readable.
-        self.assertIsInstance(ctx.exception.__cause__, RuntimeError)
-        self.assertIn("bad credentials", str(ctx.exception.__cause__))
-        # The failed client was closed (no aiohttp session leak)…
-        self.assertTrue(backend.closed)
-        # …and nothing was retained in the shared client map.
-        self.assertEqual(hass.data[DOMAIN].get("account_clients"), {})
 
 
 class _FakeIndiaVehicle:
@@ -269,29 +213,29 @@ class TestIndiaVehicleLabels(unittest.TestCase):
         self.assertEqual(flow.vehicles, ["VININDIA0001", "VININDIA0002"])
         # …and both labels carry the model plus a masked, distinguishing
         # VIN suffix (no full VIN in the label).
-        self.assertEqual(flow.vehicle_labels["VININDIA0001"], "MG Comet EV (…0001)")
-        self.assertEqual(flow.vehicle_labels["VININDIA0002"], "MG Comet EV (…0002)")
+        self.assertEqual(flow.vehicle_options["VININDIA0001"], "MG Comet EV (…A0001)")
+        self.assertEqual(flow.vehicle_options["VININDIA0002"], "MG Comet EV (…A0002)")
         self.assertNotEqual(
-            flow.vehicle_labels["VININDIA0001"],
-            flow.vehicle_labels["VININDIA0002"],
+            flow.vehicle_options["VININDIA0001"],
+            flow.vehicle_options["VININDIA0002"],
         )
 
     def test_series_used_when_model_missing(self):
         flow, _ = self._flow_after_pin(
             [_FakeIndiaVehicle("VININDIA0003", series="Comet")]
         )
-        self.assertEqual(flow.vehicle_labels["VININDIA0003"], "Comet (…0003)")
+        self.assertEqual(flow.vehicle_options["VININDIA0003"], "Comet (…A0003)")
 
     def test_metadata_free_vehicle_falls_back_to_vin(self):
         flow, result = self._flow_after_pin([_FakeIndiaVehicle("VININDIA0004")])
         self.assertEqual(result["step_id"], "select_vehicle")
-        self.assertEqual(flow.vehicle_labels["VININDIA0004"], "VININDIA0004")
+        self.assertEqual(flow.vehicle_options["VININDIA0004"], "VININDIA0004")
 
     def test_plain_string_vins_still_accepted(self):
         # The backend contract tolerates plain VIN strings.
         flow, _ = self._flow_after_pin(["VININDIA0005"])
         self.assertEqual(flow.vehicles, ["VININDIA0005"])
-        self.assertEqual(flow.vehicle_labels["VININDIA0005"], "VININDIA0005")
+        self.assertEqual(flow.vehicle_options["VININDIA0005"], "VININDIA0005")
 
 
 if __name__ == "__main__":

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -145,7 +145,20 @@ _load("mg_saic.coordinator", PKG_DIR / "coordinator.py", force=True)
 _load("mg_saic.message_poller", PKG_DIR / "message_poller.py", force=True)
 _load("mg_saic.services", PKG_DIR / "services.py", force=True)
 CF = _load("mg_saic.config_flow", PKG_DIR / "config_flow.py", force=True)
+SETUP = _load("mg_saic.setup_module", PKG_DIR / "__init__.py")
 
+
+
+class _FakeHass:
+    def __init__(self):
+        self.data = {}
+
+
+class _FakeEntry:
+    def __init__(self, data):
+        self.data = data
+        self.entry_id = "test_entry"
+        self.options = {}
 
 
 def _run(coro):
@@ -240,3 +253,146 @@ class TestIndiaVehicleLabels(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ── Issue #233 / #234 regression tests ───────────────────────────────────────
+
+import logging as _logging
+
+from mg_saic.api import SAICMGAPIClient
+
+
+class _FakeHttpxClient:
+    """Stand-in for httpx.AsyncClient with the attributes close() inspects."""
+
+    def __init__(self):
+        self.is_closed = False
+
+    async def aclose(self):
+        self.is_closed = True
+
+
+class _FakeInnerApiClient:
+    """Stand-in for SaicApiClient; owns the httpx client under the mangled name."""
+
+    def __init__(self, http_client):
+        self._SaicApiClient__client = http_client
+
+
+class _FakeSaicApi:
+    """Stand-in for SaicApi: no public close(), private transport reachable."""
+
+    def __init__(self, http_client):
+        self._AbstractSaicApi__api_client = _FakeInnerApiClient(http_client)
+
+
+class TestGlobalClientClose(unittest.TestCase):
+    """Issue #233: close() must actually close the underlying httpx transport."""
+
+    def _make_client(self, http_client):
+        client = SAICMGAPIClient.__new__(SAICMGAPIClient)
+        client.saic_api = _FakeSaicApi(http_client)
+        return client
+
+    def test_close_closes_private_transport(self):
+        http = _FakeHttpxClient()
+        client = self._make_client(http)
+        _run(client.close())
+        # The real transport is closed, not merely "close() was called".
+        self.assertTrue(http.is_closed)
+        # Reference is dropped so a second close() is a safe no-op.
+        self.assertIsNone(client.saic_api)
+
+    def test_close_is_idempotent(self):
+        http = _FakeHttpxClient()
+        client = self._make_client(http)
+        _run(client.close())
+        _run(client.close())  # must not raise
+        self.assertTrue(http.is_closed)
+
+    def test_close_prefers_public_method_when_present(self):
+        calls = []
+
+        class _WithPublicClose:
+            async def close(self):
+                calls.append("public")
+
+        client = SAICMGAPIClient.__new__(SAICMGAPIClient)
+        client.saic_api = _WithPublicClose()
+        _run(client.close())
+        self.assertEqual(calls, ["public"])
+        self.assertIsNone(client.saic_api)
+
+    def test_none_api_is_safe(self):
+        client = SAICMGAPIClient.__new__(SAICMGAPIClient)
+        client.saic_api = None
+        _run(client.close())  # must not raise
+
+
+class TestLoginFailureLogPrivacy(unittest.TestCase):
+    """Issue #234: identifiers must not appear in the error-level log line."""
+
+    def test_mask_helpers(self):
+        self.assertEqual(SETUP._mask_vin("LSJW00000000A1234"), "…1234")
+        self.assertEqual(SETUP._mask_vin("abc"), "****")
+        self.assertEqual(SETUP._mask_vin(None), "****")
+        self.assertEqual(
+            SETUP._mask_account(("driver@example.com", "India")),
+            "(d***@example.com, India)",
+        )
+        # No full username or VIN survives masking.
+        masked = SETUP._mask_account(("john.smith@gmail.com", "EU"))
+        self.assertNotIn("john.smith", masked)
+
+    def test_error_log_excludes_identifiers_and_raw_exception(self):
+        hass = _FakeHass()
+        entry = _FakeEntry(
+            {
+                "username": "secretuser@example.com",
+                "password": "wrong",
+                "region": "EU",
+                "vin": "LSJSECRETVIN12345",
+            }
+        )
+
+        class _FailingClient:
+            async def login(self):
+                raise RuntimeError("server said: token=SUPERSECRET123")
+
+            async def close(self):
+                pass
+
+        original = SETUP.create_backend
+        SETUP.create_backend = lambda data: _FailingClient()
+        records = []
+        handler = _RecordingHandler(records)
+        # Attach to the exact LOGGER object the module logs through, rather
+        # than guessing its name (it is getLogger(__package__), which differs
+        # under the test harness).
+        setup_logger = SETUP.LOGGER
+        setup_logger.addHandler(handler)
+        setup_logger.setLevel(_logging.DEBUG)
+        try:
+            with self.assertRaises(_ConfigEntryNotReady):
+                _run(SETUP.async_setup_entry(hass, entry))
+        finally:
+            SETUP.create_backend = original
+            setup_logger.removeHandler(handler)
+
+        error_text = " ".join(
+            r.getMessage() for r in records if r.levelno >= _logging.ERROR
+        )
+        self.assertIn("Failed to log in", error_text)
+        self.assertNotIn("secretuser@example.com", error_text)
+        self.assertNotIn("LSJSECRETVIN12345", error_text)
+        self.assertNotIn("SUPERSECRET123", error_text)  # raw exception text
+        self.assertNotIn("server said", error_text)
+
+
+class _RecordingHandler(_logging.Handler):
+    def __init__(self, sink):
+        super().__init__()
+        self._sink = sink
+
+    def emit(self, record):
+        self._sink.append(record)

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -1,0 +1,298 @@
+# File: tests/test_setup_and_config_flow.py
+#
+# Regression tests for issue #230 (login-failure exception path in
+# async_setup_entry) and issue #229 (India vehicle selector labels).
+#
+# Uses the same technique as tests/test_backends.py — Home Assistant and
+# third-party modules are stubbed so the integration modules load in plain
+# CPython — but with functional stub classes (rather than MagicMocks) where
+# the code under test subclasses or raises them.  Stubs are installed
+# unconditionally because tests/test_backends.py may already have installed
+# MagicMock versions in the same process; ours must win for these tests.
+
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+
+
+# ── Functional Home Assistant stubs ──────────────────────────────────────────
+
+class _ConfigEntryNotReady(Exception):
+    """Stub of homeassistant.config_entries.ConfigEntryNotReady."""
+
+
+class _ConfigFlow:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+    def async_show_form(self, step_id=None, data_schema=None, errors=None, **kw):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_abort(self, reason=None):
+        return {"type": "abort", "reason": reason}
+
+    def async_create_entry(self, title=None, data=None, options=None):
+        return {"type": "create_entry", "title": title, "data": data}
+
+
+class _OptionsFlow:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+
+class _DataUpdateCoordinator:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _install_stubs():
+    for name in (
+        "saic_ismart_client_ng",
+        "saic_ismart_client_ng.model",
+        "saic_ismart_client_ng.api",
+        "saic_ismart_client_ng.api.vehicle_charging",
+        "homeassistant.helpers",
+        "homeassistant.helpers.config_validation",
+        "homeassistant.helpers.event",
+        "homeassistant.util",
+        "homeassistant.util.dt",
+        "homeassistant.exceptions",
+    ):
+        sys.modules[name] = MagicMock()
+
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []
+    sys.modules["homeassistant"] = ha
+
+    ce = types.ModuleType("homeassistant.config_entries")
+    ce.ConfigFlow = _ConfigFlow
+    ce.OptionsFlow = _OptionsFlow
+    ce.ConfigEntry = object
+    ce.ConfigEntryNotReady = _ConfigEntryNotReady
+    sys.modules["homeassistant.config_entries"] = ce
+
+    core = types.ModuleType("homeassistant.core")
+    core.callback = lambda f: f
+    core.HomeAssistant = object
+    core.ServiceCall = object
+    sys.modules["homeassistant.core"] = core
+
+    uc = types.ModuleType("homeassistant.helpers.update_coordinator")
+    uc.DataUpdateCoordinator = _DataUpdateCoordinator
+    uc.UpdateFailed = type("UpdateFailed", (Exception,), {})
+    uc.CoordinatorEntity = _DataUpdateCoordinator
+    sys.modules["homeassistant.helpers.update_coordinator"] = uc
+
+    # Minimal voluptuous stand-in: enough for schema construction at import
+    # and step execution time.
+    vol = types.ModuleType("voluptuous")
+
+    class _Marker(str):
+        def __new__(cls, key, **kw):
+            return super().__new__(cls, key)
+
+    vol.Required = _Marker
+    vol.Optional = _Marker
+    vol.Schema = lambda d, **kw: d
+    vol.In = lambda x: x
+    vol.All = lambda *a: a
+    vol.Any = lambda *a: a
+    vol.Coerce = lambda t: t
+    vol.Range = lambda **kw: kw
+    sys.modules["voluptuous"] = vol
+
+
+def _load(name, path, force=False):
+    if name in sys.modules and not force:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_stubs()
+
+if "mg_saic" not in sys.modules or not hasattr(sys.modules["mg_saic"], "__path__"):
+    _pkg = types.ModuleType("mg_saic")
+    _pkg.__path__ = [str(PKG_DIR)]
+    sys.modules["mg_saic"] = _pkg
+
+_load("mg_saic.const", PKG_DIR / "const.py")
+_load("mg_saic.logic", PKG_DIR / "logic.py")
+_load("mg_saic.api", PKG_DIR / "api.py")
+_load("mg_saic.backends", PKG_DIR / "backends" / "__init__.py")
+sys.modules["mg_saic.backends"].__path__ = [str(PKG_DIR / "backends")]
+_load("mg_saic.backends.india", PKG_DIR / "backends" / "india.py")
+_load("mg_saic.utils", PKG_DIR / "utils.py")
+_load("mg_saic.coordinator", PKG_DIR / "coordinator.py", force=True)
+_load("mg_saic.message_poller", PKG_DIR / "message_poller.py", force=True)
+_load("mg_saic.services", PKG_DIR / "services.py", force=True)
+SETUP = _load("mg_saic.setup_module", PKG_DIR / "__init__.py")
+CF = _load("mg_saic.config_flow", PKG_DIR / "config_flow.py", force=True)
+
+DOMAIN = sys.modules["mg_saic.const"].DOMAIN
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeHass:
+    def __init__(self):
+        self.data = {}
+
+
+class _FakeEntry:
+    def __init__(self, data):
+        self.data = data
+        self.entry_id = "test_entry"
+        self.options = {}
+
+
+class _FailingBackend:
+    """Backend whose login always fails; records whether close() ran."""
+
+    def __init__(self):
+        self.closed = False
+
+    async def login(self):
+        raise RuntimeError("bad credentials")
+
+    async def close(self):
+        self.closed = True
+
+
+class TestLoginFailurePath(unittest.TestCase):
+    """Issue #230: login failure must raise ConfigEntryNotReady cleanly."""
+
+    def test_login_failure_raises_not_ready_and_cleans_up(self):
+        hass = _FakeHass()
+        entry = _FakeEntry(
+            {
+                "username": "user@example.com",
+                "password": "wrong",
+                "region": "EU",
+                "vin": "TESTVIN123",
+            }
+        )
+        backend = _FailingBackend()
+        original = SETUP.create_backend
+        SETUP.create_backend = lambda data: backend
+        try:
+            with self.assertRaises(_ConfigEntryNotReady) as ctx:
+                _run(SETUP.async_setup_entry(hass, entry))
+        finally:
+            SETUP.create_backend = original
+
+        # No secondary KeyError; the original cause is chained and readable.
+        self.assertIsInstance(ctx.exception.__cause__, RuntimeError)
+        self.assertIn("bad credentials", str(ctx.exception.__cause__))
+        # The failed client was closed (no aiohttp session leak)…
+        self.assertTrue(backend.closed)
+        # …and nothing was retained in the shared client map.
+        self.assertEqual(hass.data[DOMAIN].get("account_clients"), {})
+
+
+class _FakeIndiaVehicle:
+    def __init__(self, vin, model=None, series=None):
+        self.vin = vin
+        if model is not None:
+            self.modelName = model
+        if series is not None:
+            self.series = series
+
+
+class _FakeIndiaBackend:
+    def __init__(self, vehicles):
+        self._vehicles = vehicles
+
+    async def login(self):
+        return True
+
+    async def get_vehicle_info(self):
+        return self._vehicles
+
+    async def close(self):
+        pass
+
+
+class TestIndiaVehicleLabels(unittest.TestCase):
+    """Issue #229: the India selector shows model labels, stores VINs."""
+
+    def _flow_after_pin(self, vehicles):
+        flow = CF.SAICMGConfigFlow()
+        flow.login_type = "email"
+        flow.username = "user@example.com"
+        flow.password = "pw"
+        flow.region = "India"
+        flow.hass = MagicMock()
+        flow.hass.config_entries.async_entries.return_value = []
+        original = CF.create_backend
+        CF.create_backend = lambda data: _FakeIndiaBackend(vehicles)
+        try:
+            result = _run(flow.async_step_india_pin({"pin": "1234"}))
+        finally:
+            CF.create_backend = original
+        return flow, result
+
+    def test_model_labels_shown_and_vins_stored(self):
+        flow, result = self._flow_after_pin(
+            [
+                _FakeIndiaVehicle("VININDIA0001", model="MG Comet EV"),
+                _FakeIndiaVehicle("VININDIA0002", model="MG Comet EV"),
+            ]
+        )
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "select_vehicle")
+        # Option values are still the VINs…
+        self.assertEqual(flow.vehicles, ["VININDIA0001", "VININDIA0002"])
+        # …and both labels carry the model plus a masked, distinguishing
+        # VIN suffix (no full VIN in the label).
+        self.assertEqual(flow.vehicle_labels["VININDIA0001"], "MG Comet EV (…0001)")
+        self.assertEqual(flow.vehicle_labels["VININDIA0002"], "MG Comet EV (…0002)")
+        self.assertNotEqual(
+            flow.vehicle_labels["VININDIA0001"],
+            flow.vehicle_labels["VININDIA0002"],
+        )
+
+    def test_series_used_when_model_missing(self):
+        flow, _ = self._flow_after_pin(
+            [_FakeIndiaVehicle("VININDIA0003", series="Comet")]
+        )
+        self.assertEqual(flow.vehicle_labels["VININDIA0003"], "Comet (…0003)")
+
+    def test_metadata_free_vehicle_falls_back_to_vin(self):
+        flow, result = self._flow_after_pin([_FakeIndiaVehicle("VININDIA0004")])
+        self.assertEqual(result["step_id"], "select_vehicle")
+        self.assertEqual(flow.vehicle_labels["VININDIA0004"], "VININDIA0004")
+
+    def test_plain_string_vins_still_accepted(self):
+        # The backend contract tolerates plain VIN strings.
+        flow, _ = self._flow_after_pin(["VININDIA0005"])
+        self.assertEqual(flow.vehicles, ["VININDIA0005"])
+        self.assertEqual(flow.vehicle_labels["VININDIA0005"], "VININDIA0005")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# 1.1.5

This release focuses on **battery-friendly polling**, **clearer visibility into when your car is actually reachable**, and **first-class support for MG India vehicles** — alongside a large round of resilience and test work under the hood.

## ✨ Highlights

### 🛌 Deep-sleep awareness & new Reachability sensor
After a car sits idle for a long time (often around a day), its telematics module drops into a deep sleep to protect the 12V battery. While asleep it can still answer *cached* status requests, but live commands fail with SAIC's "can't reach the car" error (return code 4) — normal vehicle behaviour, not an integration fault.

A new **Reachability** sensor now surfaces this at a glance, with three states:
- **awake** — the car is responding normally
- **likely_asleep** — no reported activity for longer than the configurable *data staleness threshold* (default 12h); data may be stale
- **unreachable** — a live command recently failed with return code 4 (the car confirming it can't be reached)

State is inferred from the **car's own reported activity**, not from how often the integration polls, so slowing your polling won't make it read asleep incorrectly. Supporting attributes (`hours_since_activity`, `last_command_unreachable`, `data_age_hours`, `reported_battery_voltage`, `holiday_mode`) provide evidence without driving the state.

> This matters more on **PHEVs** than BEVs: a PHEV only tops up its 12V while running, so one left parked is more likely to drift into deep sleep — and once asleep, often only driving reliably wakes it.

### 🏖️ Holiday Mode
A new switch that slows idle polling right down while you're away, reducing how often the telematics module is woken and cutting 12V drain (especially useful on PHEVs).
- **Persists across restarts** — a Home Assistant reboot while you're away won't silently resume fast polling. HA still performs one immediate poll on restart so data is fresh, then resumes the holiday cadence.
- The `Next Update Time` / `Last Update Time` sensors reflect the holiday cadence so you can confirm it's active.
- Configurable **holiday mode idle interval** (default 12h) and **data staleness threshold** (default 12h).

> Holiday mode reduces *Home Assistant's* share of the wake-ups. The car and the official iSmart app also poll it, so for very long storage a dedicated 12V maintenance charger remains the reliable safeguard.

### 🇮🇳 MG India support
Full support for MG India vehicles: select **India** as your region and enter your **4-digit iSmart PIN** (the same one you use in the iSmart India app). Only a secure one-way hash of the PIN is stored — the PIN itself is never saved. The vehicle picker now shows the model name with a shortened VIN (e.g. "MG Comet EV (…0001)") rather than a raw VIN.

## 🔧 Improvements
- **Login resilience** — setup now retries after an initial login failure and raises `ConfigEntryNotReady` instead of failing hard, so transient SAIC outages recover on their own. Login failure messages are clearer.
- **Climate control** — remote climate commands now accept a temperature override, and front-defrost requests are blocked where they'd conflict with the current climate state.
- **LHD/RHD naming** — door and window naming corrected for both left- and right-hand-drive vehicles.
- **Clearer vehicle picker** — vehicles are presented with friendly labels (model + shortened VIN) during setup.

## 🔒 Privacy & robustness
- **Log masking** — VINs and account identifiers are now masked in logs.
- **Re-entrancy guard** on `async_setup_entry` prevents overlapping setup runs.
- **Error recording** for service calls and refined unreachable-flag logic on vehicle commands.
- Improved general error handling against the MG SAIC API.

## 🧪 Under the hood
- Substantial new test coverage: setup, config flow, core logic, and login-failure regressions.
- Translations updated: English, Spanish, French, Portuguese.

---

**Full changelog:** https://github.com/townsmcp/mg-saic-ha/compare/1.1.4...1.1.5