### PR TITLE
fix(#238): flag Reachability + stop live sensors dropping to unavailable on code 4

### DIFF
--- a/custom_components/mg_saic/api.py
+++ b/custom_components/mg_saic/api.py
@@ -13,6 +13,7 @@ from .const import (
     LOGGER,
     REGION_API_CODES,
     REGION_BASE_URIS,
+    SAIC_RETURN_CODE_UNREACHABLE,
     BatterySoc,
     ChargeCurrentLimitOption,
 )
@@ -166,6 +167,13 @@ class SAICMGAPIClient:
             return charging_status
         except Exception as e:
             LOGGER.error("Error retrieving charging information for VIN %s: %s", target_vin, e)
+            # Return code 4 = "can't reach the car right now". Propagate it so the
+            # coordinator can flag the Vehicle Reachability sensor as
+            # 'unreachable'; previously this was swallowed into a None return,
+            # which the coordinator reported only as a generic "is None" error
+            # and never recognised as an unreachable condition (#238).
+            if f"return code: {SAIC_RETURN_CODE_UNREACHABLE}" in str(e):
+                raise
             return None
 
     async def get_vehicle_info(self):
@@ -195,6 +203,13 @@ class SAICMGAPIClient:
             return vehicle_status
         except Exception as e:
             LOGGER.error("Error retrieving vehicle status for VIN %s: %s", target_vin, e)
+            # Return code 4 = "can't reach the car right now". Propagate it so the
+            # coordinator can flag the Vehicle Reachability sensor as
+            # 'unreachable'; previously this was swallowed into a None return,
+            # which the coordinator reported only as a generic "is None" error
+            # and never recognised as an unreachable condition (#238).
+            if f"return code: {SAIC_RETURN_CODE_UNREACHABLE}" in str(e):
+                raise
             return None
 
     # ACTIONS

--- a/custom_components/mg_saic/binary_sensor.py
+++ b/custom_components/mg_saic/binary_sensor.py
@@ -442,6 +442,13 @@ class SAICMGChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
         self._device_info = create_device_info(coordinator, entry.entry_id)
 
+        # Last known good state, retained so the plug/charging state does not
+        # drop to 'unavailable' when a poll returns no charging data (e.g. the
+        # car was unreachable). Gun/plug state is persistent (not a live
+        # measurement), so holding the last value is appropriate — mirrors the
+        # status binary sensors. See #238.
+        self._last_valid_state: bool | None = None
+
     @property
     def unique_id(self):
         """Return the unique ID of the binary sensor."""
@@ -456,6 +463,8 @@ class SAICMGChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def available(self):
         """Return True if the entity is available."""
+        if self._last_valid_state is not None:
+            return True
         required_data = self.coordinator.data.get(self._data_type)
         return self.coordinator.last_update_success and required_data is not None
 
@@ -468,8 +477,12 @@ class SAICMGChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
             if data_source:
                 value = getattr(data_source, self._field, None)
                 if value is not None:
-                    return bool(value)
-        return None
+                    state = bool(value)
+                    self._last_valid_state = state
+                    return state
+        # No fresh reading — retain the last known state rather than dropping to
+        # 'unavailable' while the car is temporarily unreachable. See #238.
+        return self._last_valid_state
 
     @property
     def device_class(self):

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.6-beta1"
+  "version": "1.1.6-beta2"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -1510,8 +1510,12 @@ class SAICMGInstantPowerSensor(CoordinatorEntity, SensorEntity):
         """Return True if the entity is available."""
         if self._last_valid_power is not None:
             return True
-        required_data = self.coordinator.data.get(self._data_type)
-        return self.coordinator.last_update_success and required_data is not None
+        # Car unreachable / poll returned no data: report 'unknown'
+        # (entity available, value None) rather than 'unavailable'. A stale
+        # live reading would be misleading, so we don't retain one here; the
+        # Vehicle Reachability sensor signals that the data isn't current.
+        # See #238.
+        return self.coordinator.last_update_success
 
     @property
     def native_value(self):
@@ -1759,8 +1763,12 @@ class SAICMGChargingCurrentSensor(CoordinatorEntity, SensorEntity):
         """Return True if the entity is available."""
         if self._last_valid_current is not None:
             return True
-        required_data = self.coordinator.data.get(self._data_type)
-        return self.coordinator.last_update_success and required_data is not None
+        # Car unreachable / poll returned no data: report 'unknown'
+        # (entity available, value None) rather than 'unavailable'. A stale
+        # live reading would be misleading, so we don't retain one here; the
+        # Vehicle Reachability sensor signals that the data isn't current.
+        # See #238.
+        return self.coordinator.last_update_success
 
     @property
     def native_value(self):
@@ -1895,8 +1903,12 @@ class SAICMGChargingPowerSensor(CoordinatorEntity, SensorEntity):
         """Return True if the entity is available."""
         if self._last_valid_power is not None:
             return True
-        required_data = self.coordinator.data.get(self._data_type)
-        return self.coordinator.last_update_success and required_data is not None
+        # Car unreachable / poll returned no data: report 'unknown'
+        # (entity available, value None) rather than 'unavailable'. A stale
+        # live reading would be misleading, so we don't retain one here; the
+        # Vehicle Reachability sensor signals that the data isn't current.
+        # See #238.
+        return self.coordinator.last_update_success
 
     @property
     def native_value(self):
@@ -2066,8 +2078,12 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
         """Return True if the entity is available."""
         if self._last_valid_value is not None:
             return True
-        required_data = self.coordinator.data.get(self._data_type)
-        return self.coordinator.last_update_success and required_data is not None
+        # Car unreachable / poll returned no data: report 'unknown'
+        # (entity available, value None) rather than 'unavailable'. A stale
+        # live reading would be misleading, so we don't retain one here; the
+        # Vehicle Reachability sensor signals that the data isn't current.
+        # See #238.
+        return self.coordinator.last_update_success
 
     @property
     def native_value(self):
@@ -2660,8 +2676,12 @@ class SAICMGVehicleSpeedSensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self):
         """Return True if the entity is available."""
-        required_data = self.coordinator.data.get(self._data_type)
-        return self.coordinator.last_update_success and required_data is not None
+        # Car unreachable / poll returned no data: report 'unknown'
+        # (entity available, value None) rather than 'unavailable'. A stale
+        # live reading would be misleading, so we don't retain one here; the
+        # Vehicle Reachability sensor signals that the data isn't current.
+        # See #238.
+        return self.coordinator.last_update_success
 
     @property
     def native_value(self):

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -396,3 +396,58 @@ class _RecordingHandler(_logging.Handler):
 
     def emit(self, record):
         self._sink.append(record)
+
+
+class TestUnreachableCode4Propagation(unittest.TestCase):
+    """Regression tests for issue #238.
+
+    The Vehicle Reachability sensor stayed on 'Awake' after a failed status
+    poll because api.get_vehicle_status / get_charging_info caught the SAIC
+    'return code: 4' (car unreachable) exception and returned None. The
+    coordinator then only ever saw a generic "status is None" error and never
+    recognised the unreachable condition, so it never flagged reachability.
+
+    These tests pin the corrected contract: a return-code-4 failure must
+    propagate (so the coordinator's retry handler can flag it), while any
+    other failure still degrades to None as before.
+    """
+
+    def setUp(self):
+        api = sys.modules["mg_saic.api"]
+        self.client = api.SAICMGAPIClient("user@example.com", "pw", vin="VINTEST123")
+        # saic_api is referenced when building the call arguments; a bare mock
+        # is enough since _make_api_call is replaced in each test.
+        self.client.saic_api = MagicMock()
+
+    @staticmethod
+    def _run(coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def _patch_make_api_call(self, exc):
+        async def _boom(*args, **kwargs):
+            raise exc
+        self.client._make_api_call = _boom
+
+    def test_status_propagates_code_4(self):
+        self._patch_make_api_call(
+            Exception("return code: 4, message: The remote control instruction failed")
+        )
+        with self.assertRaises(Exception) as ctx:
+            self._run(self.client.get_vehicle_status("VINTEST123"))
+        self.assertIn("return code: 4", str(ctx.exception))
+
+    def test_charging_propagates_code_4(self):
+        self._patch_make_api_call(
+            Exception("return code: 4, message: The remote control instruction failed")
+        )
+        with self.assertRaises(Exception) as ctx:
+            self._run(self.client.get_charging_info("VINTEST123"))
+        self.assertIn("return code: 4", str(ctx.exception))
+
+    def test_status_other_error_returns_none(self):
+        self._patch_make_api_call(Exception("some transient network blip"))
+        self.assertIsNone(self._run(self.client.get_vehicle_status("VINTEST123")))
+
+    def test_charging_other_error_returns_none(self):
+        self._patch_make_api_call(Exception("some transient network blip"))
+        self.assertIsNone(self._run(self.client.get_charging_info("VINTEST123")))


### PR DESCRIPTION
beta1 didn't fix the reported behaviour. Two root causes:

1. Reachability stayed 'Awake' after a failed poll. api.get_vehicle_status and get_charging_info caught the SAIC 'return code: 4' (car unreachable) exception and returned None, so the coordinator only ever saw a generic "status is None" error. The code-4 detection in _fetch_with_retries never matched. Fix: propagate the code-4 exception from both API methods (other errors still degrade to None), so the existing coordinator detection fires and flips Reachability to 'unreachable' immediately.

2. Some sensors still went 'unavailable' when the car was unreachable:
   - Charging Gun State (a persistent state) now retains its last value, mirroring the lock/boot binary sensors.
   - Live measurements (Speed, Charging Current/Power/Voltage, Added Electric Range, Remaining Charging Time) now report 'unknown' (available, no value) instead of 'unavailable' when a poll returns no data. They still do NOT retain a stale reading — a stale live value would mislead — which matches the Speed sensor's documented intent and the Reachability sensor signals that the data isn't current.

Adds regression tests pinning the code-4 propagation contract.