### PR TITLE
Fix/243 climate fan speed safe values

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ The MG SAIC integration exposes a climate entity for remote control of the vehic
  
 Not all MG models expose climate control the same way, so the integration uses one of two schemes depending on your vehicle:
  
-- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes. This is the default and covers the MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
-- **Mode-select models (e.g. MG S9 PHEV):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle.
+- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes. This is the default and covers the standard MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
+- **Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle. Available modes and presets vary by model — a car is only offered `Heat` or a `Defrost` preset if it actually supports them (the MG4 EV URBAN, for example, has no heat mode).
  
 ### How commands are used
  
@@ -280,7 +280,7 @@ Front defrost (the standalone **Front Defrost switch**, and the **Defrost preset
 | `Fan Only` | Runs the fan without the compressor (blowing only) |
 | `Off` | Stops all climate activity |
  
-### Mode-select models (e.g. MG S9 PHEV)
+### Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN)
  
 On these models there is **no fan-speed slider** — the car manages its own fan. Control is via HVAC modes and presets instead:
  
@@ -292,6 +292,8 @@ On these models there is **no fan-speed slider** — the car manages its own fan
 | HVAC `Off` | Stops all climate activity |
 | Preset `Max Cool` | Strong fixed-fan fast cool-down |
 | Preset `Defrost` | Windscreen / upper-vent defrost |
+ 
+> **Note:** not every mode-select car offers all of these. `Heat` and the `Defrost` preset are only shown on models that actually support them. The **MG4 EV URBAN**, for example, has no heat mode, so it shows only `Cool` / `Fan Only` / `Off` plus the `Max Cool` and `Defrost` presets — the Defrost preset gives URBAN owners a front-defrost control the iSmart app itself doesn't provide.
  
 > **⚠️ Note for MG S9 PHEV owners:** from **1.1.2** this model uses the mode-select scheme. The previous Low/Med/High fan control has been replaced by the HVAC modes and presets above. If you have automations or scripts that called `climate.set_fan_mode` on your S9 PHEV, update them to use `climate.set_hvac_mode` (`cool` / `heat` / `fan_only`) or `climate.set_preset_mode` (`Max Cool` / `Defrost`) instead.
  
@@ -471,6 +473,7 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
 | Series | Model | Notes |
 |---|---|---|
 | `EH32` | MG4 Electric | Temperature range and fan speed values confirmed |
+| `AH4EM` | MG4 EV URBAN | Mode-select climate scheme (owner-confirmed, #243); this variant has no heat mode — see [Climate Control](#climate-control) |
 | `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index; model year override (API reports 2024, corrected to 2025) |
 | `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |
 | `IS31P` | MG S9 PHEV (2025) | Climate status/fan speed mappings confirmed by physical testing |

--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -103,21 +103,28 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         self._last_command_ts = 0.0
 
         if self._scheme == "mode_select":
-            # Mode-select cars: no fan slider, but add Heat + presets.
+            # Mode-select cars: no fan slider. Heat and the Defrost preset are
+            # only offered when the profile actually defines them. Some variants
+            # (e.g. the MG4 EV URBAN, series AH4EM — see #243) have no heat mode
+            # at all; offering an HVAC mode the car can't perform is misleading
+            # and sending it does nothing useful.
+            hvac_modes = [HVACMode.OFF, HVACMode.FAN_ONLY, HVACMode.COOL]
+            if coordinator.climate_status_heat:
+                hvac_modes.append(HVACMode.HEAT)
+            self._attr_hvac_modes = hvac_modes
+
+            preset_modes = [PRESET_NONE, PRESET_MAX_COOL]
+            if coordinator.climate_status_defrost:
+                preset_modes.append(PRESET_DEFROST)
+            self._attr_preset_modes = preset_modes
+            self._attr_preset_mode = PRESET_NONE
+
             self._attr_supported_features = (
                 ClimateEntityFeature.TARGET_TEMPERATURE
                 | ClimateEntityFeature.PRESET_MODE
                 | ClimateEntityFeature.TURN_ON
                 | ClimateEntityFeature.TURN_OFF
             )
-            self._attr_hvac_modes = [
-                HVACMode.OFF,
-                HVACMode.FAN_ONLY,
-                HVACMode.COOL,
-                HVACMode.HEAT,
-            ]
-            self._attr_preset_modes = [PRESET_NONE, PRESET_MAX_COOL, PRESET_DEFROST]
-            self._attr_preset_mode = PRESET_NONE
             self._attr_fan_modes = None
             self._attr_fan_mode = None
         else:

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -167,10 +167,14 @@ VEHICLE_PROFILES = {
         "climate_status_cool": {3},
         "climate_status_fan_only": {2},
         # Fan speed values for cooling mode (1=low, 2=med, 3=high).
-        # On MG4 values 4 and 5 trigger heating/defrost — avoid them.
+        # Byte values 4 and 5 are NOT higher fan speeds — on MG4-family cars
+        # they trigger heating/front-defrost. Sending 5 as "High" put the car
+        # into front defrost and made it report remoteClimateStatus=5 (which the
+        # integration then read as defrost, not cooling). See #243. Keep the
+        # slider strictly within the safe 1/2/3 range.
         "fan_speed_low": 1,
-        "fan_speed_medium": 3,
-        "fan_speed_high": 5,
+        "fan_speed_medium": 2,
+        "fan_speed_high": 3,
         # Temperature index direction: False = forward (low temp -> low idx)
         "temp_idx_inverted": False,
         # Whether the car supports setting a Target SOC via the SAIC API.
@@ -399,9 +403,15 @@ DEFAULT_VEHICLE_PROFILE = {
     "battery_capacity_kwh": None,
     "climate_status_cool": {3},
     "climate_status_fan_only": {2},
+    # Fan byte values 4 and 5 are unsafe on the SAIC climate protocol — on
+    # MG-family cars they trigger heating/front-defrost rather than a faster
+    # fan. Selecting "High" previously sent 5, which put unprofiled MG4-family
+    # cars (e.g. the MG4 EV URBAN, series AH4EM) into front defrost and made
+    # them report remoteClimateStatus=5 — read by the integration as defrost,
+    # not cooling. Keep the slider within the safe 1/2/3 range. See #243.
     "fan_speed_low": 1,
-    "fan_speed_medium": 3,
-    "fan_speed_high": 5,
+    "fan_speed_medium": 2,
+    "fan_speed_high": 3,
     "temp_idx_inverted": False,
     # Default: assume Target SOC is supported (safe for BEV/PHEV unless known otherwise).
     "supports_target_soc": True,

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -187,6 +187,46 @@ VEHICLE_PROFILES = {
         # instead of the per-second live value, which the API returns as -128.
         "reliable_fuel_range_elec": True,
     },
+    "AH4EM": {  # MG4 EV URBAN (entry variant; series 'AH4EM L')
+        # Confirmed by olflo (#243) through direct testing. Despite being an
+        # MG4, this variant does NOT use the fan-speed scheme of the standard
+        # MG4 (EH32). It uses mode_select: the API's "fan_speed" byte is a MODE
+        # selector that the car echoes back verbatim as remoteClimateStatus.
+        # Tested (value sent == remoteClimateStatus observed):
+        #   1 -> fan only  (HVAC runs but does not cool)
+        #   2 -> cooling, auto fan (follows target temp) — the default "cool"
+        #   3 -> cooling, stronger fan — exposed as the "Max Cool" preset
+        #   5 -> front defrost
+        # The car has NO heat mode: the iSmart app offers no heating and HA
+        # showed only off/cool/fan_only. climate_status_heat is left unset,
+        # which now suppresses the Heat HVAC mode (see climate.py). The iSmart
+        # app has no front-defrost button either, so exposing the Defrost preset
+        # (mode 5, confirmed working) actually gives the owner a control the app
+        # lacks.
+        #
+        # Temperature range/offset follow the MG4 (EH32); the car still honours a
+        # target temperature under the cool modes. Not independently re-verified
+        # for this variant — revisit if an owner reports the target temperature
+        # landing wrong.
+        "min_temp": 17,
+        "max_temp": 33,
+        "temp_offset": 3,
+        "battery_capacity_kwh": None,
+        "temp_idx_inverted": False,
+        "supports_target_soc": True,
+        "reliable_fuel_range_elec": True,
+        # --- mode_select climate scheme ---
+        "climate_control_scheme": "mode_select",
+        "climate_mode_fan_only": 1,
+        "climate_mode_cool": 2,
+        "climate_mode_max_cool": 3,
+        "climate_mode_defrost": 5,
+        # No climate_mode_heat — this model has no heating.
+        "climate_status_fan_only": {1},
+        "climate_status_cool": {2, 3},
+        "climate_status_defrost": {5},
+        # No climate_status_heat — leaving it unset suppresses the Heat mode.
+    },
     "MIS3E": {  # MGS6 EV (Long Range and Dual Motor)
         "min_temp": 16,
         "max_temp": 30,

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.6-beta2"
+  "version": "1.1.6-beta3"
 }

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -451,3 +451,39 @@ class TestUnreachableCode4Propagation(unittest.TestCase):
     def test_charging_other_error_returns_none(self):
         self._patch_make_api_call(Exception("some transient network blip"))
         self.assertIsNone(self._run(self.client.get_charging_info("VINTEST123")))
+
+
+class TestClimateFanSpeedSafeValues(unittest.TestCase):
+    """Regression tests for issue #243.
+
+    On the SAIC climate protocol the fan-speed byte values 4 and 5 are not
+    higher fan speeds — on MG-family cars they trigger heating / front-defrost.
+    Sending 5 as "High" put an unprofiled MG4 EV URBAN (series AH4EM, which
+    falls back to DEFAULT_VEHICLE_PROFILE) into front defrost and made it report
+    remoteClimateStatus=5, which the integration read as defrost rather than
+    cooling. The fan-speed slider for the fixed profiles must therefore stay
+    within the safe 1/2/3 range.
+    """
+
+    SAFE = {1, 2, 3}
+
+    def _fan_values(self, profile):
+        return [
+            profile[k]
+            for k in ("fan_speed_low", "fan_speed_medium", "fan_speed_high")
+            if k in profile
+        ]
+
+    def test_default_profile_fan_speeds_are_safe(self):
+        const = sys.modules["mg_saic.const"]
+        vals = self._fan_values(const.DEFAULT_VEHICLE_PROFILE)
+        self.assertTrue(vals, "default profile should define fan speeds")
+        for v in vals:
+            self.assertIn(v, self.SAFE, f"unsafe fan byte {v} in DEFAULT profile")
+
+    def test_eh32_profile_fan_speeds_are_safe(self):
+        const = sys.modules["mg_saic.const"]
+        vals = self._fan_values(const.VEHICLE_PROFILES["EH32"])
+        self.assertTrue(vals, "EH32 profile should define fan speeds")
+        for v in vals:
+            self.assertIn(v, self.SAFE, f"unsafe fan byte {v} in EH32 profile")

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -487,3 +487,38 @@ class TestClimateFanSpeedSafeValues(unittest.TestCase):
         self.assertTrue(vals, "EH32 profile should define fan speeds")
         for v in vals:
             self.assertIn(v, self.SAFE, f"unsafe fan byte {v} in EH32 profile")
+
+
+class TestMG4UrbanProfile(unittest.TestCase):
+    """Issue #243: MG4 EV URBAN (series AH4EM) profile.
+
+    Confirmed by owner testing that this variant uses the mode_select scheme
+    (the fan byte is a mode the car echoes back as remoteClimateStatus), with
+    no heat mode. Pin the confirmed value maps so a future edit can't silently
+    revert them.
+    """
+
+    def _profile(self):
+        return sys.modules["mg_saic.const"].VEHICLE_PROFILES["AH4EM"]
+
+    def test_uses_mode_select_scheme(self):
+        self.assertEqual(self._profile()["climate_control_scheme"], "mode_select")
+
+    def test_confirmed_status_maps(self):
+        p = self._profile()
+        self.assertEqual(p["climate_status_fan_only"], {1})
+        self.assertEqual(p["climate_status_cool"], {2, 3})
+        self.assertEqual(p["climate_status_defrost"], {5})
+
+    def test_confirmed_mode_values(self):
+        p = self._profile()
+        self.assertEqual(p["climate_mode_fan_only"], 1)
+        self.assertEqual(p["climate_mode_cool"], 2)
+        self.assertEqual(p["climate_mode_max_cool"], 3)
+        self.assertEqual(p["climate_mode_defrost"], 5)
+
+    def test_no_heat_mode(self):
+        # No heat status means the climate entity must not offer HVAC heat.
+        p = self._profile()
+        self.assertNotIn("climate_status_heat", p)
+        self.assertNotIn("climate_mode_heat", p)


### PR DESCRIPTION
# Merge notes — `fix/243-climate-fan-speed-safe-values` → `beta`

Fixes #243 (HVAC strange behaviour / wrong state on MG4 EV URBAN). Three commits:

**1. `356ba0a` — keep the climate fan-speed slider within the safe 1/2/3 range**
On the SAIC protocol, fan bytes 4 and 5 are not higher fan speeds — on MG-family cars they trigger heat/front-defrost. `DEFAULT_VEHICLE_PROFILE` and `EH32` (standard MG4) both mapped "High" to byte 5, so selecting High for cooling put the car into front defrost. Remapped low/medium/high to 1/2/3 in both profiles. General safety fix for fan-speed models.

**2. `603c8ef` — add the MG4 EV URBAN (`AH4EM`) mode-select profile; hide unsupported modes**
Owner testing (olflo) confirmed the URBAN is *not* a fan-speed car like the standard MG4: its "fan" byte is a mode selector the car echoes back as `remoteClimateStatus` (1 = fan only, 2 = cool/auto fan, 3 = cool/strong fan, 5 = front defrost), and it has no heat mode. Added an `AH4EM` profile using the `mode_select` scheme with the confirmed maps. Also made mode-select cars offer `Heat` only when the profile defines a heat status, and the `Defrost` preset only when it defines a defrost status, rather than hardcoding both (IS31P and MIS3E define both, so they're unaffected).

**3. `3757920` — docs + version**
README: added `AH4EM` to the built-in-profiles table, flagged the standard MG4 vs URBAN distinction in the climate-scheme section, and noted that `Heat`/`Defrost` only appear on models that support them. Bumped manifest to `1.1.6-beta3`.

## Testing
- 52 unit tests pass (`python -m unittest discover -s tests`). New regression tests pin the AH4EM value maps + the no-heat contract, and assert DEFAULT/EH32 never use fan bytes 4/5.
- All modules compile.

## Version
Manifest set to `1.1.6-beta3` (beta2 already released). If the ABRP branch is merged after this, bump it to `1.1.6-beta4` so the two don't collide.

## Not included (deliberate, tracked for follow-up)
- `EC32` (Cyberster) and `AS33P` (HS PHEV) still use the unsafe 1/3/5 fan mapping — same latent issue, left alone pending owner confirmation.
- Open question: whether the *standard* MG4 (`EH32`) is also secretly mode-select like the URBAN. Needs a standard-MG4 owner's test data before changing it.
- `SAICMGFrontDefrostSwitch.is_on` still hardcodes `remoteClimateStatus == 5`; correct for every current profile, but could read `climate_status_defrost` for full generality.