### PR TITLE
feat(#173): add PTC resistive Heat mode for the MG4 (EH32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - AC Control Climate entity
   * Temperature
   * Fan Speed *(most models)* **or** HVAC mode + Preset *(mode-select models, e.g. MG S9 PHEV — see [Climate Control](#climate-control))*
-  * HVAC mode (Cool / Fan Only / Off, plus Heat on mode-select models)
+  * HVAC mode (Cool / Fan Only / Off, plus Heat on models with a heater — the MG4 Electric, and mode-select models that support it)
 ### SLIDERS
 - Target SOC *(shown only on models where the iSmart app supports it)*
 ### SELECT
@@ -232,7 +232,7 @@ The MG SAIC integration exposes a climate entity for remote control of the vehic
  
 Not all MG models expose climate control the same way, so the integration uses one of two schemes depending on your vehicle:
  
-- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes. This is the default and covers the standard MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
+- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes (and `Heat` on models with a confirmed heater, e.g. the MG4 Electric). This is the default and covers the standard MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
 - **Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle. Available modes and presets vary by model — a car is only offered `Heat` or a `Defrost` preset if it actually supports them (the MG4 EV URBAN, for example, has no heat mode).
  
 ### How commands are used
@@ -277,8 +277,11 @@ Front defrost (the standalone **Front Defrost switch**, and the **Defrost preset
 | Mode | Behaviour |
 |---|---|
 | `Cool` | Runs the compressor with your chosen temperature and fan speed |
+| `Heat` | Runs the resistive (PTC) heater — **shown only on models with a heater, e.g. the MG4 Electric.** Heats to the top of the temperature range (this is how the car's own app drives it) |
 | `Fan Only` | Runs the fan without the compressor (blowing only) |
 | `Off` | Stops all climate activity |
+
+> **Note:** `Heat` appears only on models where resistive heating has been confirmed. On the MG4 Electric it engages the PTC heater; because of how the car works, heating always runs at the top of the temperature range rather than a chosen setpoint.
  
 ### Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN)
  
@@ -472,7 +475,7 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
  
 | Series | Model | Notes |
 |---|---|---|
-| `EH32` | MG4 Electric | Temperature range and fan speed values confirmed |
+| `EH32` | MG4 Electric | Temperature range and fan speed values confirmed; PTC resistive **Heat** mode supported (#173) |
 | `AH4EM` | MG4 EV URBAN | Mode-select climate scheme (owner-confirmed, #243); this variant has no heat mode — see [Climate Control](#climate-control) |
 | `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index; model year override (API reports 2024, corrected to 2025) |
 | `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |

--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -142,6 +142,12 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
                 HVACMode.COOL,
                 HVACMode.FAN_ONLY,
             ]
+            # Some fan-speed cars also have a heater (e.g. the MG4's PTC
+            # resistive heater — #173). Only offer Heat when the profile defines
+            # a heat status, so cars without confirmed heating don't show a mode
+            # that does nothing.
+            if coordinator.climate_status_heat:
+                self._attr_hvac_modes.append(HVACMode.HEAT)
             self._attr_fan_modes = [FAN_LOW, FAN_MEDIUM, FAN_HIGH]
             self._attr_fan_mode = FAN_MEDIUM
 
@@ -369,6 +375,22 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
                 temperature_idx=self._temperature_idx(),
                 fan_speed=self._fan_speed_to_int(),
                 ac_on=True,
+            )
+        elif hvac_mode == HVACMode.HEAT:
+            # PTC resistive heating (e.g. MG4). Confirmed from decrypted iSmart
+            # traffic (#173): the heater engages only with the compressor OFF
+            # (ac_on=False) AND the AUTO fan value; any other fan value does
+            # nothing. The app drives it to the top of the temperature range, so
+            # we send the max index. Only reachable when the profile defines a
+            # heat status (see __init__), so cars without a confirmed heater
+            # never hit this path.
+            await self._client.start_climate(
+                self._vin,
+                temperature_idx=self.coordinator.get_ac_temperature_idx(
+                    int(self.max_temp)
+                ),
+                fan_speed=self.coordinator.heat_fan_speed,
+                ac_on=False,
             )
         elif hvac_mode == HVACMode.FAN_ONLY:
             await self._client.start_ac(

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -162,10 +162,15 @@ VEHICLE_PROFILES = {
         "max_temp": 33,
         "temp_offset": 3,
         "battery_capacity_kwh": None,
-        # remoteClimateStatus values that indicate AC is running in cooling mode.
-        # On MG4, status=3 is confirmed cooling and status=2 is fan-only blowing.
+        # remoteClimateStatus decode, confirmed from decrypted iSmart traffic
+        # and live telemetry (PR #173, kindel0): 2 = HEAT (PTC resistive heater
+        # active), 3 = COOL (compressor active). 4 is assumed fan-only by
+        # elimination (not independently confirmed). The MG4 heats with the
+        # compressor OFF and the AUTO fan value — see the heat path in
+        # climate.py (_set_hvac_fan_speed).
         "climate_status_cool": {3},
-        "climate_status_fan_only": {2},
+        "climate_status_heat": {2},
+        "climate_status_fan_only": {4},
         # Fan speed values for cooling mode (1=low, 2=med, 3=high).
         # Byte values 4 and 5 are NOT higher fan speeds — on MG4-family cars
         # they trigger heating/front-defrost. Sending 5 as "High" put the car

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -200,6 +200,10 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # climate_status_fan_only above.)
         self.climate_status_heat: set = set()
         self.climate_status_defrost: set = set()
+        # Fan value that engages PTC resistive heating on fan-speed cars that
+        # have a heater (compressor off + this AUTO value). MG4-confirmed as 2
+        # (#173). Only used when the profile defines a heat status.
+        self.heat_fan_speed: int = 2
         # Per-model feature flags — set from VEHICLE_PROFILES on first data fetch.
         self.supports_target_soc: bool = True
         self.reliable_fuel_range_elec: bool = True
@@ -745,6 +749,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.climate_mode_defrost = profile.get("climate_mode_defrost", 5)
             self.climate_status_heat = profile.get("climate_status_heat", set())
             self.climate_status_defrost = profile.get("climate_status_defrost", set())
+            self.heat_fan_speed = profile.get("heat_fan_speed", 2)
             self.supports_target_soc = profile.get("supports_target_soc", True)
             self.reliable_fuel_range_elec = profile.get("reliable_fuel_range_elec", True)
             self.charging_capacity_correction = profile.get("charging_capacity_correction", None)

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.6-beta3"
+  "version": "1.1.6-beta4"
 }

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -530,3 +530,34 @@ class TestMG4UrbanProfile(unittest.TestCase):
         p = self._profile()
         self.assertNotIn("climate_status_heat", p)
         self.assertNotIn("climate_mode_heat", p)
+
+
+class TestMG4HeatProfile(unittest.TestCase):
+    """MG4 (EH32) PTC heat support — ported from PR #173 (kindel0).
+
+    The standard MG4 heats via a PTC resistive heater, triggered with the
+    compressor off and the AUTO fan value. remoteClimateStatus 2 = heat,
+    3 = cool (confirmed from decrypted iSmart traffic + live telemetry).
+    """
+
+    def _profile(self):
+        return sys.modules["mg_saic.const"].VEHICLE_PROFILES["EH32"]
+
+    def test_status_map(self):
+        p = self._profile()
+        self.assertEqual(p["climate_status_heat"], {2})
+        self.assertEqual(p["climate_status_cool"], {3})
+        self.assertEqual(p["climate_status_fan_only"], {4})
+
+    def test_is_fan_speed_scheme(self):
+        # EH32 stays a fan-speed car (not mode_select like the URBAN); the
+        # heat command lives in the fan_speed path.
+        p = self._profile()
+        self.assertNotEqual(p.get("climate_control_scheme", "fan_speed"), "mode_select")
+
+    def test_fan_speeds_still_safe(self):
+        # Heat uses fan byte 2 with the compressor off; the cooling slider must
+        # still avoid the unsafe 4/5 values (#243).
+        p = self._profile()
+        for k in ("fan_speed_low", "fan_speed_medium", "fan_speed_high"):
+            self.assertIn(p[k], {1, 2, 3})


### PR DESCRIPTION
Ports the findings of the long-standing PR #173 (kindel0) into the current profile-based architecture. The standard MG4 heats via a PTC resistive heater, which engages only with the compressor OFF and the AUTO fan value (confirmed from decrypted iSmart traffic + live telemetry); any other fan value does nothing. remoteClimateStatus 2 = heat, 3 = cool.

- Fan-speed cars now offer HVAC `Heat` when their profile defines a heat status (gated the same way as the mode-select scheme), and the fan-speed handler sends the confirmed heat command: compressor off, AUTO fan, max temperature index (matching how the car's own app drives it).
- New coordinator `heat_fan_speed` (profile-overridable, default 2 = AUTO).
- EH32 profile: `climate_status_heat={2}`, `climate_status_cool={3}` (unchanged), and `climate_status_fan_only` corrected from `{2}` to `{4}` — the old value mislabelled active heating as fan-only.
- README + regression tests updated.

Credit: original investigation and decrypted-traffic mapping by @kindel0 (#173).

Note: based on the #243 branch, so merging this into beta brings both the MG4 EV URBAN fix and this heat feature in one go. Manifest set to 1.1.6-beta4.