### PR TITLE
fix(#238): don't flag Reachability 'unreachable' while the car is powered on

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1679,6 +1679,19 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         flag is cleared automatically on the next successful status update.
         Drives the Vehicle Reachability sensor's 'unreachable' state.
         """
+        # A powered-on car is, by definition, reachable. A return code 4 ("the
+        # remote control instruction failed, please try again later") while the
+        # car is on/driving is a transient backend hiccup, not the car being
+        # unreachable — honouring it made Reachability flip-flop to 'unreachable'
+        # and back on every transient failure during a drive (reported by
+        # @SteveMSJ on #238). Only flag when the car isn't powered on; a
+        # genuinely unreachable parked car reports is_powered_on=False.
+        if self.is_powered_on:
+            LOGGER.debug(
+                "Ignoring return-code-%s unreachable flag: vehicle is powered on",
+                SAIC_RETURN_CODE_UNREACHABLE,
+            )
+            return
         self._last_command_unreachable = True
         self._last_command_unreachable_time = datetime.now(timezone.utc)
         LOGGER.debug(

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.6-beta4"
+  "version": "1.1.6-beta5"
 }

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -561,3 +561,32 @@ class TestMG4HeatProfile(unittest.TestCase):
         p = self._profile()
         for k in ("fan_speed_low", "fan_speed_medium", "fan_speed_high"):
             self.assertIn(p[k], {1, 2, 3})
+
+
+class TestReachabilityWhilePoweredOn(unittest.TestCase):
+    """Regression test for #238.
+
+    A powered-on (driving) car must NOT flip to 'unreachable' on a transient
+    return code 4 — that caused Reachability to flip-flop during a drive. Only a
+    car that isn't powered on should be flagged unreachable.
+    """
+
+    def _coordinator(self, powered_on):
+        Coord = sys.modules["mg_saic.coordinator"].SAICMGDataUpdateCoordinator
+        c = Coord.__new__(Coord)
+        c.is_powered_on = powered_on
+        c._last_command_unreachable = False
+        c._last_command_unreachable_time = None
+        c.vin = "TESTVIN"
+        c.async_update_listeners = lambda: None
+        return c
+
+    def test_powered_on_suppresses_unreachable(self):
+        c = self._coordinator(powered_on=True)
+        c.note_command_unreachable()
+        self.assertFalse(c._last_command_unreachable)
+
+    def test_powered_off_allows_unreachable(self):
+        c = self._coordinator(powered_on=False)
+        c.note_command_unreachable()
+        self.assertTrue(c._last_command_unreachable)


### PR DESCRIPTION
SteveMSJ reported Reachability flip-flopping to 'unreachable' during a drive. A transient return code 4 ("remote control instruction failed, please try again later") on a status poll set the unreachable flag; the next successful poll cleared it, so it toggled repeatedly while the car was demonstrably powered on and reporting.

A powered-on car is by definition reachable, so note_command_unreachable now ignores the code-4 flag when is_powered_on is True. A genuinely unreachable parked car reports is_powered_on=False and is still flagged correctly (the original #238 case). Bump to 1.1.6-beta5.