### PR TITLE
fix(#238): debounce the code-4 'unreachable' signal instead of gating on power

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -68,6 +68,14 @@ from .const import (
 )
 
 
+# Number of consecutive polls that must fail to bring fresh data (with a return
+# code 4) before the Vehicle Reachability sensor is flagged 'unreachable'. A
+# single transient "remote control instruction failed, please try again later"
+# during a drive should not flip the sensor; a car that's genuinely out of
+# contact will fail repeatedly and cross this threshold. See #238.
+UNREACHABLE_CONSECUTIVE_POLL_THRESHOLD = 2
+
+
 class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the MG SAIC API."""
 
@@ -134,6 +142,13 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self._last_command_unreachable = False
         self._last_command_unreachable_time = None
+        # Debounce for the code-4 'unreachable' signal: only flag after this many
+        # consecutive polls fail to bring fresh data, so a single transient "try
+        # again later" during a drive doesn't flip the sensor (#238). Reset by
+        # any positive proof of reachability (fresh status, detected activity, a
+        # successful command).
+        self._consecutive_unreachable_polls = 0
+        self._code4_this_cycle = False
         # Highest vehicle-reported statusTime we've seen. A response whose
         # statusTime advances beyond this is positive proof the telematics just
         # reported fresh data (not a cached response served while asleep), and
@@ -851,6 +866,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         account.
         """
         data = {}
+        # Reset the per-cycle marker; note_command_unreachable() sets it if a
+        # code 4 is seen during this cycle's fetches (#238 debounce).
+        self._code4_this_cycle = False
 
         # _api_lock is injected by __init__ before async_setup is called.
         # Fall back to a no-op context if somehow not set (single-entry case
@@ -1046,9 +1064,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             ):
                 fresh_status = True
                 self._last_status_time = new_status_time
-        if self.is_powered_on or fresh_status:
-            self._last_command_unreachable = False
-            self._last_command_unreachable_time = None
+        self._update_reachability_after_poll(fresh_status)
 
         # Include capabilities in the returned data
         data["capabilities"] = {
@@ -1146,8 +1162,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             # Genuine detected activity (doors, lock, engine, journey change) is
             # positive proof the car is awake — clear any stale unreachable flag.
             # This is distinct from a plain cached-status poll, which is not.
-            self._last_command_unreachable = False
-            self._last_command_unreachable_time = None
+            self._mark_reachable()
 
         # Notify listeners of data changes
         self.async_update_listeners()
@@ -1669,41 +1684,68 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 "Command succeeded; clearing unreachable flag for VIN %s",
                 getattr(self, "vin", "?"),
             )
+        self._mark_reachable()
+
+    def _mark_reachable(self) -> None:
+        """Clear the unreachable flag and reset the debounce counter.
+
+        Called on positive proof the car is reachable: a status response with a
+        fresh (advanced) statusTime, genuine detected activity, or a successful
+        live command.
+        """
         self._last_command_unreachable = False
         self._last_command_unreachable_time = None
+        self._consecutive_unreachable_polls = 0
+
+    def _update_reachability_after_poll(self, fresh_status: bool) -> None:
+        """Apply the code-4 debounce at the end of a poll cycle.
+
+        - Fresh status this cycle → proof of reachability, reset everything.
+        - Otherwise, if this cycle saw a code 4 with no fresh data, count it;
+          flag 'unreachable' only once enough consecutive polls have failed, so
+          a transient mid-drive hiccup doesn't flip the sensor (#238).
+        """
+        if fresh_status:
+            self._mark_reachable()
+        elif self._code4_this_cycle:
+            self._consecutive_unreachable_polls += 1
+            if (
+                self._consecutive_unreachable_polls
+                >= UNREACHABLE_CONSECUTIVE_POLL_THRESHOLD
+                and not self._last_command_unreachable
+            ):
+                self._last_command_unreachable = True
+                self._last_command_unreachable_time = datetime.now(timezone.utc)
+                LOGGER.debug(
+                    "Vehicle flagged unreachable after %s consecutive failed "
+                    "polls for VIN %s",
+                    self._consecutive_unreachable_polls,
+                    getattr(self, "vin", "?"),
+                )
 
     def note_command_unreachable(self) -> None:
-        """Flag that a live command failed with the 'can't reach car' code (4).
+        """Record that a live command/poll failed with the 'can't reach car'
+        code (4) this cycle.
 
-        Called from command error handling when the SAIC return code is 4. The
-        flag is cleared automatically on the next successful status update.
-        Drives the Vehicle Reachability sensor's 'unreachable' state.
+        This no longer flips the Vehicle Reachability sensor on its own. A single
+        code 4 ("remote control instruction failed, please try again later") is
+        often just a transient backend hiccup — flagging on the first one made
+        the sensor flip-flop to 'unreachable' and back throughout a drive
+        (reported by @SteveMSJ on #238). Instead we mark that this cycle saw a
+        code 4; only after several consecutive polls fail to bring fresh data
+        (see the debounce in _async_update_data) is the car flagged unreachable.
+        This also fixes the related edge case Steve raised — a car that stops in
+        a no-signal spot right after a drive: is_powered_on is still 'on' from
+        the last good poll, but because fresh data stops arriving the consecutive
+        failures still cross the threshold and it correctly reads 'unreachable'.
         """
-        # A powered-on car is, by definition, reachable. A return code 4 ("the
-        # remote control instruction failed, please try again later") while the
-        # car is on/driving is a transient backend hiccup, not the car being
-        # unreachable — honouring it made Reachability flip-flop to 'unreachable'
-        # and back on every transient failure during a drive (reported by
-        # @SteveMSJ on #238). Only flag when the car isn't powered on; a
-        # genuinely unreachable parked car reports is_powered_on=False.
-        if self.is_powered_on:
-            LOGGER.debug(
-                "Ignoring return-code-%s unreachable flag: vehicle is powered on",
-                SAIC_RETURN_CODE_UNREACHABLE,
-            )
-            return
-        self._last_command_unreachable = True
-        self._last_command_unreachable_time = datetime.now(timezone.utc)
+        self._code4_this_cycle = True
         LOGGER.debug(
-            "Vehicle reported unreachable (return code %s) for VIN %s",
+            "Return code %s seen this cycle for VIN %s (consecutive so far: %s)",
             SAIC_RETURN_CODE_UNREACHABLE,
             getattr(self, "vin", "?"),
+            self._consecutive_unreachable_polls,
         )
-        # Push the new state to entities immediately. A command failure happens
-        # between polls, so without this the Reachability sensor would keep
-        # showing "awake" until the next scheduled refresh (up to hours later in
-        # a long/holiday interval) — which is exactly what #238 reported.
-        self.async_update_listeners()
 
     @property
     def vehicle_reachability(self) -> str:

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.1.6-beta5"
+  "version": "1.1.6-beta6"
 }

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -563,30 +563,61 @@ class TestMG4HeatProfile(unittest.TestCase):
             self.assertIn(p[k], {1, 2, 3})
 
 
-class TestReachabilityWhilePoweredOn(unittest.TestCase):
-    """Regression test for #238.
+class TestReachabilityDebounce(unittest.TestCase):
+    """Regression tests for #238.
 
-    A powered-on (driving) car must NOT flip to 'unreachable' on a transient
-    return code 4 — that caused Reachability to flip-flop during a drive. Only a
-    car that isn't powered on should be flagged unreachable.
+    A single transient return code 4 must NOT flip Reachability to 'unreachable'
+    (SteveMSJ's driving flip-flop). Only after several consecutive polls fail to
+    bring fresh data is the car flagged — which also covers a car that stops in a
+    no-signal spot right after a drive (is_powered_on still 'on', but fresh data
+    stops arriving so the failures still accumulate).
     """
 
-    def _coordinator(self, powered_on):
+    def _coordinator(self):
         Coord = sys.modules["mg_saic.coordinator"].SAICMGDataUpdateCoordinator
         c = Coord.__new__(Coord)
-        c.is_powered_on = powered_on
         c._last_command_unreachable = False
         c._last_command_unreachable_time = None
+        c._consecutive_unreachable_polls = 0
+        c._code4_this_cycle = False
         c.vin = "TESTVIN"
-        c.async_update_listeners = lambda: None
         return c
 
-    def test_powered_on_suppresses_unreachable(self):
-        c = self._coordinator(powered_on=True)
+    def _failed_poll(self, c):
+        # Mimic a cycle: reset marker, note a code 4, evaluate with no fresh data.
+        c._code4_this_cycle = False
+        c.note_command_unreachable()
+        c._update_reachability_after_poll(fresh_status=False)
+
+    def _fresh_poll(self, c):
+        c._code4_this_cycle = False
+        c._update_reachability_after_poll(fresh_status=True)
+
+    def test_single_transient_code4_does_not_flag(self):
+        c = self._coordinator()
+        self._failed_poll(c)  # one isolated failure
+        self.assertFalse(c._last_command_unreachable)
+        self._fresh_poll(c)  # next poll succeeds
+        self.assertFalse(c._last_command_unreachable)
+        self.assertEqual(c._consecutive_unreachable_polls, 0)
+
+    def test_sustained_failures_flag_unreachable(self):
+        c = self._coordinator()
+        for _ in range(sys.modules["mg_saic.coordinator"].UNREACHABLE_CONSECUTIVE_POLL_THRESHOLD):
+            self._failed_poll(c)
+        self.assertTrue(c._last_command_unreachable)
+
+    def test_fresh_status_clears_and_resets(self):
+        c = self._coordinator()
+        for _ in range(5):
+            self._failed_poll(c)
+        self.assertTrue(c._last_command_unreachable)
+        self._fresh_poll(c)  # car reports again
+        self.assertFalse(c._last_command_unreachable)
+        self.assertEqual(c._consecutive_unreachable_polls, 0)
+
+    def test_note_command_unreachable_does_not_flag_directly(self):
+        c = self._coordinator()
         c.note_command_unreachable()
         self.assertFalse(c._last_command_unreachable)
-
-    def test_powered_off_allows_unreachable(self):
-        c = self._coordinator(powered_on=False)
-        c.note_command_unreachable()
-        self.assertTrue(c._last_command_unreachable)
+        self.assertTrue(c._code4_this_cycle)


### PR DESCRIPTION
Follow-up to the beta5 fix. @SteveMSJ pointed out that suppressing the unreachable flag whenever the car is powered on has a gap: a car that stops in a no-signal spot right after a drive still reads is_powered_on=True (from the last good poll), so a genuine loss of contact would be wrongly suppressed.

Replace the powered-on guard with a consecutive-failure debounce that doesn't depend on the (lagging) power state:

- note_command_unreachable() no longer flips the sensor; it just records that a code 4 was seen this cycle.
- At the end of each poll cycle, fresh status (advanced statusTime) proves reachability and resets everything; a cycle that saw a code 4 with no fresh data increments a counter, and only at UNREACHABLE_CONSECUTIVE_POLL_THRESHOLD (2) consecutive failures is the car flagged unreachable.
- The flag now clears only on positive proof (fresh status, detected activity, or a successful command) via a shared _mark_reachable() helper — no longer on a stale powered-on reading.

This keeps a driving car steady on 'Awake' through isolated transient failures (the original report) while correctly flagging a car that has genuinely dropped off, powered-on-state notwithstanding (Steve's edge case). Regression tests cover both. Bump to 1.1.6-beta6.