### PR TITLE
i18n(#250): translate reauth/reconfigure strings + password guidance (es, fr, pt)

### DIFF
--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -19,6 +19,9 @@
           "password": "Contraseña",
           "region": "Región",
           "country_code": "Código de País"
+        },
+        "data_description": {
+          "password": "Introduce la misma contraseña que usas en la app iSmart. Evita espacios al final al pegarla. Las contraseñas muy largas generadas por un gestor de contraseñas pueden fallar aquí aunque la app las acepte, porque los servidores de SAIC las acortan al guardarlas; si el inicio de sesión falla con una contraseña larga, establece una más corta (unos 16 caracteres o menos) en la app y usa esa."
         }
       },
       "custom_region": {
@@ -56,6 +59,16 @@
         "data": {
           "pin": "PIN iSmart de 4 dígitos"
         }
+      },
+      "reauth_confirm": {
+        "title": "Actualizar la contraseña de MG SAIC",
+        "description": "La contraseña guardada para {username} ya no funciona, o has solicitado actualizarla. Introduce la contraseña actual de iSmart para volver a conectar; se conserva el resto de la configuración.",
+        "data": {
+          "password": "Contraseña"
+        },
+        "data_description": {
+          "password": "Evita espacios al final al pegarla. Si una contraseña larga de un gestor de contraseñas falla, establece una más corta (unos 16 caracteres o menos) en la app iSmart e introdúcela."
+        }
       }
     },
     "error": {
@@ -64,7 +77,9 @@
     },
     "abort": {
       "already_configured": "All vehicles on this account are already configured in Home Assistant.",
-      "india_backend_not_ready": "La compatibilidad con MG India está en desarrollo y aún no es funcional en esta versión. Sigue el issue #169 en GitHub para conocer el progreso."
+      "india_backend_not_ready": "La compatibilidad con MG India está en desarrollo y aún no es funcional en esta versión. Sigue el issue #169 en GitHub para conocer el progreso.",
+      "reauth_successful": "La reautenticación se ha realizado correctamente; la contraseña se ha actualizado.",
+      "reconfigure_successful": "La contraseña se ha actualizado correctamente."
     }
   },
   "services": {

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -19,6 +19,9 @@
           "password": "Mot de passe",
           "region": "Région",
           "country_code": "Code pays"
+        },
+        "data_description": {
+          "password": "Saisissez le mot de passe exact que vous utilisez dans l'application iSmart. Évitez les espaces en fin de chaîne lors du collage. Les mots de passe très longs générés par un gestionnaire de mots de passe peuvent échouer ici même si l'application les accepte, car les serveurs SAIC les raccourcissent lors de leur enregistrement ; si la connexion échoue avec un mot de passe long, définissez-en un plus court (environ 16 caractères ou moins) dans l'application et utilisez celui-ci."
         }
       },
       "custom_region": {
@@ -56,6 +59,16 @@
         "data": {
           "pin": "PIN iSmart à 4 chiffres"
         }
+      },
+      "reauth_confirm": {
+        "title": "Mettre à jour le mot de passe MG SAIC",
+        "description": "Le mot de passe enregistré pour {username} ne fonctionne plus, ou vous avez demandé à le mettre à jour. Saisissez le mot de passe iSmart actuel pour vous reconnecter — le reste de vos paramètres est conservé.",
+        "data": {
+          "password": "Mot de passe"
+        },
+        "data_description": {
+          "password": "Évitez les espaces en fin de chaîne lors du collage. Si un long mot de passe issu d'un gestionnaire de mots de passe échoue, définissez-en un plus court (environ 16 caractères ou moins) dans l'application iSmart et saisissez-le."
+        }
       }
     },
     "error": {
@@ -65,7 +78,9 @@
     "abort": {
       "vin": "Le véhicule avec le VIN {vin} est déjà configuré.",
       "already_configured": "Tous les véhicules de ce compte sont déjà configurés dans Home Assistant.",
-      "india_backend_not_ready": "La prise en charge de MG India est en cours de développement et n'est pas encore fonctionnelle dans cette version. Suivez l'issue #169 sur GitHub pour connaître l'avancement."
+      "india_backend_not_ready": "La prise en charge de MG India est en cours de développement et n'est pas encore fonctionnelle dans cette version. Suivez l'issue #169 sur GitHub pour connaître l'avancement.",
+      "reauth_successful": "La ré-authentification a réussi ; le mot de passe a été mis à jour.",
+      "reconfigure_successful": "Le mot de passe a été mis à jour avec succès."
     }
   },
   "services": {

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -19,6 +19,9 @@
           "password": "Palavra-passe",
           "region": "Região",
           "country_code": "Código do País"
+        },
+        "data_description": {
+          "password": "Introduza a palavra-passe exata que utiliza na aplicação iSmart. Evite espaços no final ao colar. Palavras-passe muito longas geradas por um gestor de palavras-passe podem falhar aqui, mesmo que a aplicação as aceite, porque os servidores da SAIC encurtam-nas ao guardá-las; se o início de sessão falhar com uma palavra-passe longa, defina uma mais curta (cerca de 16 caracteres ou menos) na aplicação e utilize essa."
         }
       },
       "custom_region": {
@@ -56,6 +59,16 @@
         "data": {
           "pin": "PIN iSmart de 4 dígitos"
         }
+      },
+      "reauth_confirm": {
+        "title": "Atualizar a palavra-passe MG SAIC",
+        "description": "A palavra-passe guardada para {username} já não funciona, ou pediu para a atualizar. Introduza a palavra-passe atual do iSmart para voltar a ligar — o resto das suas definições é mantido.",
+        "data": {
+          "password": "Palavra-passe"
+        },
+        "data_description": {
+          "password": "Evite espaços no final ao colar. Se uma palavra-passe longa de um gestor de palavras-passe falhar, defina uma mais curta (cerca de 16 caracteres ou menos) na aplicação iSmart e introduza-a."
+        }
       }
     },
     "error": {
@@ -65,7 +78,9 @@
     "abort": {
       "vin": "Veículo com VIN {vin} já configurado.",
       "already_configured": "All vehicles on this account are already configured in Home Assistant.",
-      "india_backend_not_ready": "O suporte para a MG Índia está em desenvolvimento e ainda não é funcional nesta versão. Acompanhe a issue #169 no GitHub para ver o progresso."
+      "india_backend_not_ready": "O suporte para a MG Índia está em desenvolvimento e ainda não é funcional nesta versão. Acompanhe a issue #169 no GitHub para ver o progresso.",
+      "reauth_successful": "A reautenticação foi bem-sucedida; a palavra-passe foi atualizada.",
+      "reconfigure_successful": "A palavra-passe foi atualizada com sucesso."
     }
   },
   "services": {


### PR DESCRIPTION
Adds the reauth_confirm step, the login password guidance, and the reauth_successful/reconfigure_successful abort messages (added to en.json in 1.1.7-beta1) to the Spanish, French and Portuguese translations.