### PR TITLE
fix(#238): fast-retry after a failed update cycle so charges aren't missed

### DIFF
--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -510,6 +510,18 @@ UPDATE_INTERVAL_POWERED = timedelta(minutes=15)
 UPDATE_INTERVAL_AFTER_SHUTDOWN = timedelta(minutes=2)
 UPDATE_INTERVAL_GRACE_PERIOD = timedelta(minutes=10)
 
+# When an update cycle fails outright (e.g. a transient "return code 4" that
+# exhausts its retries), the interval-selection step never runs, so the
+# coordinator would otherwise keep whatever interval the last *successful* cycle
+# chose — which can be a multi-hour idle interval. If that failed poll happened
+# to be the first of a charging session, the car's charge would go completely
+# unpolled until the next idle wake-up (#238, MG HS PHEV). To avoid that, a
+# failed cycle retries after this shorter interval instead — but only for a
+# bounded number of consecutive failures, so a car that is genuinely away or
+# asleep for a long time is not polled every few minutes indefinitely.
+UPDATE_INTERVAL_AFTER_FAILURE = timedelta(minutes=5)
+MAX_FAST_RETRIES_AFTER_FAILURE = 3
+
 # After action immediate and refresh intervals
 AFTER_ACTION_UPDATE_INTERVAL_DELAY = timedelta(seconds=15)
 

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -60,6 +60,8 @@ from .const import (
     STATUS_TIMESTAMP_MAX_AGE,
     UPDATE_INTERVAL,
     UPDATE_INTERVAL_AFTER_SHUTDOWN,
+    UPDATE_INTERVAL_AFTER_FAILURE,
+    MAX_FAST_RETRIES_AFTER_FAILURE,
     UPDATE_INTERVAL_CHARGING,
     UPDATE_INTERVAL_DC_CHARGING,
     UPDATE_INTERVAL_GRACE_PERIOD,
@@ -154,6 +156,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # reported fresh data (not a cached response served while asleep), and
         # is used to clear the 'unreachable' flag when the car wakes. See #238.
         self._last_status_time = None
+        # Bounded fast-retry after a failed update cycle (#238). A failed poll
+        # skips interval selection, so without this the coordinator would keep
+        # the last successful cycle's interval — potentially a multi-hour idle
+        # value — and miss an active charge. Reset on any successful cycle.
+        self._consecutive_update_failures = 0
+        self.failure_retry_interval = UPDATE_INTERVAL_AFTER_FAILURE
         self._action_refresh_task = None
         self._action_refresh_generation = 0
 
@@ -853,6 +861,56 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         return True
 
     async def _async_update_data(self):
+        """Coordinator entry point.
+
+        Wraps the real update cycle so that a failed cycle doesn't leave the
+        coordinator parked on a long idle interval. When the cycle raises before
+        interval selection runs (e.g. a transient "return code 4" that exhausts
+        its retries), the last successful cycle's interval would otherwise stand
+        — which can be several hours — so an active charge that began just before
+        the failed poll would go unpolled until the next idle wake-up (#238).
+
+        On failure we shorten the next retry (capped so it never *lengthens* an
+        already-short interval), but only for a bounded number of consecutive
+        failures, so a car that is genuinely away or asleep isn't polled every
+        few minutes forever. Any successful cycle resets the counter.
+        """
+        try:
+            data = await self._run_update_cycle()
+        except Exception:
+            self._consecutive_update_failures += 1
+            if self._consecutive_update_failures <= MAX_FAST_RETRIES_AFTER_FAILURE:
+                # Possibly a transient failure at the start of a charge — retry
+                # soon, capped so we never lengthen an already-short interval.
+                self.update_interval = min(
+                    self.update_interval, self.failure_retry_interval
+                )
+                LOGGER.debug(
+                    "Update cycle failed for VIN %s (failure %d/%d); retrying in "
+                    "%s instead of the idle interval.",
+                    self.vin,
+                    self._consecutive_update_failures,
+                    MAX_FAST_RETRIES_AFTER_FAILURE,
+                    self.update_interval,
+                )
+            else:
+                # Sustained failure: the car is probably genuinely away or
+                # asleep. Fall back to the normal idle cadence so we don't keep
+                # polling (and risk waking) it every few minutes indefinitely.
+                self.update_interval = self.default_update_interval
+                LOGGER.debug(
+                    "Update cycle still failing for VIN %s after %d fast retries; "
+                    "backing off to the idle interval (%s).",
+                    self.vin,
+                    MAX_FAST_RETRIES_AFTER_FAILURE,
+                    self.update_interval,
+                )
+            raise
+        else:
+            self._consecutive_update_failures = 0
+            return data
+
+    async def _run_update_cycle(self):
         """Fetch data from the API.
 
         All network calls are made while holding the account-level _api_lock.
@@ -1733,7 +1791,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         the sensor flip-flop to 'unreachable' and back throughout a drive
         (reported by @SteveMSJ on #238). Instead we mark that this cycle saw a
         code 4; only after several consecutive polls fail to bring fresh data
-        (see the debounce in _async_update_data) is the car flagged unreachable.
+        (see the debounce in _run_update_cycle) is the car flagged unreachable.
         This also fixes the related edge case Steve raised — a car that stops in
         a no-signal spot right after a drive: is_powered_on is still 'on' from
         the last good poll, but because fresh data stops arriving the consecutive

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -772,3 +772,88 @@ class TestReauthPrefill(unittest.TestCase):
         self.assertEqual(flow.username, "driver@example.com")
         self.assertEqual(flow.region, "EU")
         self.assertEqual(result["step_id"], "reauth_confirm")
+
+
+# ── #238: a failed update cycle must not park on a long idle interval ─────────
+
+
+class TestFailedCycleFastRetry(unittest.TestCase):
+    """A failed cycle skips interval selection; the wrapper must shorten the
+    next retry (bounded) so an active charge isn't missed for hours (#238)."""
+
+    def _coord(self, update_interval, default_interval=None):
+        from datetime import timedelta
+
+        mod = sys.modules["mg_saic.coordinator"]
+        c = mod.SAICMGDataUpdateCoordinator.__new__(mod.SAICMGDataUpdateCoordinator)
+        c.vin = "TESTVIN"
+        c.update_interval = update_interval
+        c.default_update_interval = default_interval or timedelta(hours=6)
+        c.failure_retry_interval = mod.UPDATE_INTERVAL_AFTER_FAILURE
+        c._consecutive_update_failures = 0
+        return c, mod
+
+    def test_failure_caps_long_idle_interval(self):
+        from datetime import timedelta
+
+        c, mod = self._coord(timedelta(hours=6))
+
+        async def _boom():
+            raise Exception("return code 4")
+
+        c._run_update_cycle = _boom
+        with self.assertRaises(Exception):
+            _run(c._async_update_data())
+        self.assertEqual(c.update_interval, mod.UPDATE_INTERVAL_AFTER_FAILURE)
+        self.assertEqual(c._consecutive_update_failures, 1)
+
+    def test_failure_never_lengthens_a_short_interval(self):
+        from datetime import timedelta
+
+        short = timedelta(minutes=2)
+        c, mod = self._coord(short)
+
+        async def _boom():
+            raise Exception("x")
+
+        c._run_update_cycle = _boom
+        with self.assertRaises(Exception):
+            _run(c._async_update_data())
+        # min(2min, 5min) == 2min — we don't slow down an already-fast cadence.
+        self.assertEqual(c.update_interval, short)
+
+    def test_success_resets_counter_and_preserves_interval(self):
+        from datetime import timedelta
+
+        c, mod = self._coord(timedelta(hours=6))
+        c._consecutive_update_failures = 2
+
+        async def _ok():
+            return {"ok": True}
+
+        c._run_update_cycle = _ok
+        result = _run(c._async_update_data())
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(c._consecutive_update_failures, 0)
+        self.assertEqual(c.update_interval, timedelta(hours=6))
+
+    def test_sustained_failures_back_off_to_idle(self):
+        from datetime import timedelta
+
+        idle = timedelta(hours=6)
+        c, mod = self._coord(idle)
+
+        async def _boom():
+            raise Exception("x")
+
+        c._run_update_cycle = _boom
+        max_fast = mod.MAX_FAST_RETRIES_AFTER_FAILURE
+        for _ in range(max_fast):
+            with self.assertRaises(Exception):
+                _run(c._async_update_data())
+        self.assertEqual(c.update_interval, mod.UPDATE_INTERVAL_AFTER_FAILURE)
+        # One more failure crosses the bound → revert to the idle cadence.
+        with self.assertRaises(Exception):
+            _run(c._async_update_data())
+        self.assertEqual(c.update_interval, idle)
+        self.assertEqual(c._consecutive_update_failures, max_fast + 1)


### PR DESCRIPTION
A failed update cycle raises before interval selection runs, so the coordinator kept whatever interval the last successful cycle chose. If that failed poll was the first of a charging session, is_charging was never set and the interval stayed at the (user-configurable, potentially multi-hour) idle value — so the whole charge went unpolled until the next idle wake-up. Reported by @HarryFlatter on an MG HS PHEV: a transient "return code 4" at charge start left "Next update scheduled in 6:00:00".

- Wrap _async_update_data: on failure, cap the next retry to a short interval (UPDATE_INTERVAL_AFTER_FAILURE, 5 min) using min() so it never lengthens an already-short cadence.
- Bound it: after MAX_FAST_RETRIES_AFTER_FAILURE (3) consecutive failures, fall back to the idle interval so a genuinely absent/asleep car isn't polled every few minutes indefinitely. Any successful cycle resets the counter.
- Rename the update-cycle body to _run_update_cycle; the wrapper is now _async_update_data.
- Tests: cap on long idle, no-lengthen on short, success resets, and back-off after the bound. Full suite green (74 tests).

Deep-sleep detection is unaffected (it's a non-exception path).