### PR TITLE
feat(#238): add Data Freshness diagnostic sensor + humanize command-error events

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Mileage Since Last Charge
 - Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value)*
 - Battery Heating Status *(if equipped)*
-- Reachability *(deep-sleep / data-freshness indicator — see [Deep sleep & holiday mode](#deep-sleep--holiday-mode))*
+- Reachability *(is the car awake / likely asleep / unreachable — see [Deep sleep & holiday mode](#deep-sleep--holiday-mode))*
+- Data Freshness *(diagnostic: whether the last poll returned `live`, `cached` or `failed` data — see [Data Freshness sensor](#data-freshness-sensor))*
 ### BINARY SENSORS
  
 #### Doors
@@ -186,7 +187,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - **Command Errors** — a single event entity with two possible event types:
   - `command_error` — fired when a remote command (lock, AC, charge, etc.) fails or is rejected by the vehicle.
   - `command_limit_reached` — fired specifically when the vehicle's remote-command allowance has been used up.
-  Use this in automations to get notified when a command does not go through.
+  Use this in automations to get notified when a command does not go through. Each event carries readable attributes rather than raw API text: `action` (what was attempted, e.g. "Setting HVAC mode"), `reason` (a plain-English explanation, e.g. "The car couldn't be reached…"), `code` (the SAIC return code where applicable, e.g. `4` or `8`), and `detail` (the original error string, kept for debugging).
 ### DEVICE TRACKER
 - Latitude
 - Longitude
@@ -376,6 +377,16 @@ The state is inferred from the **car's own reported activity**, not from how oft
 **Attributes** provide supporting evidence (none of which drives the state): `reported_battery_voltage` (see note), `hours_since_activity`, `last_command_unreachable`, `data_age_hours`, and `holiday_mode`.
  
 > **Battery voltage note:** the reported aux-battery voltage is shown only as an attribute, never used to decide the state. The vehicle can mis-report its own aux voltage (one owner saw 11.7V reported in HA while a calibrated external monitor read 12.13V at the same moment), so it is surfaced as a rough early-warning hint, clearly labelled as possibly inaccurate.
+ 
+### Data Freshness sensor
+ 
+The **Data Freshness** sensor is a diagnostic entity that answers a different question from Reachability. Reachability describes the **car's** state (awake / asleep / unreachable); Data Freshness describes the **data's** state — how current the information from the most recent poll actually is. The two are separate on purpose: the car can be reachable while the poll still returns cached data. It has three states:
+ 
+- **live** — the last poll returned a status whose timestamp advanced, i.e. genuinely fresh data straight from the car
+- **cached** — the poll succeeded, but SAIC served the same, unchanged status (typical when the car is asleep and not reporting new data)
+- **failed** — the last poll errored (for example a transient `return code 4`)
+ 
+Like Reachability, it stays **always available** — including when polls are failing, since that's exactly when its `failed` state is most useful. It carries a single `last_update` attribute (when the current data was last refreshed). This is the reliable signal to gate automations on: for example, only fire a remote command when Data Freshness is `live` (or Reachability is `awake`), so you're not sending commands at a car that isn't listening.
  
 ### Holiday mode
  

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - **Command Errors** — a single event entity with two possible event types:
   - `command_error` — fired when a remote command (lock, AC, charge, etc.) fails or is rejected by the vehicle.
   - `command_limit_reached` — fired specifically when the vehicle's remote-command allowance has been used up.
-  Use this in automations to get notified when a command does not go through. Each event carries readable attributes rather than raw API text: `action` (what was attempted, e.g. "Setting HVAC mode"), `reason` (a plain-English explanation, e.g. "The car couldn't be reached…"), `code` (the SAIC return code where applicable, e.g. `4` or `8`), and `detail` (the original error string, kept for debugging).
+  Use this in automations to get notified when a command does not go through. Alongside the original `source` and `error` attributes (still present), each event now also carries readable ones: `action` (what was attempted, e.g. "Setting HVAC mode"), `reason` (a plain-English explanation, e.g. "The car couldn't be reached…"), and `code` (the SAIC return code where applicable, e.g. `4` or `8`).
 ### DEVICE TRACKER
 - Latitude
 - Longitude

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -662,6 +662,14 @@ CONF_HOLIDAY_UPDATE_INTERVAL = "holiday_update_interval"
 VEHICLE_REACHABILITY_AWAKE = "awake"
 VEHICLE_REACHABILITY_LIKELY_ASLEEP = "likely_asleep"
 VEHICLE_REACHABILITY_UNREACHABLE = "unreachable"
+
+# Data Freshness sensor (#238): how current the data from the last poll was.
+# A separate axis from reachability — the car can be "awake" while the poll
+# still returned "cached" data. Values stay lowercase snake_case so
+# automations/templates match on them; translations provide display labels.
+DATA_FRESHNESS_LIVE = "live"
+DATA_FRESHNESS_CACHED = "cached"
+DATA_FRESHNESS_FAILED = "failed"
 # Hours of vehicle inactivity after which data is treated as possibly stale.
 # Configurable; default sits comfortably inside the observed ~1-day sleep onset.
 DEFAULT_STALE_DATA_THRESHOLD_HOURS = 12

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -31,6 +31,9 @@ from .const import (
     REMOTE_CLIMATE_STATUS_DEFROST,
     REMOTE_CLIMATE_STATUS_OFF,
     SAIC_RETURN_CODE_UNREACHABLE,
+    DATA_FRESHNESS_LIVE,
+    DATA_FRESHNESS_CACHED,
+    DATA_FRESHNESS_FAILED,
     VEHICLE_REACHABILITY_AWAKE,
     VEHICLE_REACHABILITY_LIKELY_ASLEEP,
     VEHICLE_REACHABILITY_UNREACHABLE,
@@ -162,6 +165,10 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # value — and miss an active charge. Reset on any successful cycle.
         self._consecutive_update_failures = 0
         self.failure_retry_interval = UPDATE_INTERVAL_AFTER_FAILURE
+        # Data Freshness (#238): result of the most recent poll — live (fresh
+        # data), cached (poll succeeded but data unchanged), or failed (poll
+        # errored). None until the first cycle completes.
+        self._last_poll_result = None
         self._action_refresh_task = None
         self._action_refresh_generation = 0
 
@@ -879,6 +886,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             data = await self._run_update_cycle()
         except Exception:
             self._consecutive_update_failures += 1
+            self._last_poll_result = DATA_FRESHNESS_FAILED
             if self._consecutive_update_failures <= MAX_FAST_RETRIES_AFTER_FAILURE:
                 # Possibly a transient failure at the start of a charge — retry
                 # soon, capped so we never lengthen an already-short interval.
@@ -1123,6 +1131,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 fresh_status = True
                 self._last_status_time = new_status_time
         self._update_reachability_after_poll(fresh_status)
+        # Record how current this cycle's data was, for the Data Freshness
+        # sensor. A poll that returns unchanged/cached status is "cached", not
+        # "live" — the same distinction the reachability debounce relies on.
+        self._last_poll_result = (
+            DATA_FRESHNESS_LIVE if fresh_status else DATA_FRESHNESS_CACHED
+        )
 
         # Include capabilities in the returned data
         data["capabilities"] = {
@@ -1846,6 +1860,21 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             if stale_for >= self.stale_data_threshold:
                 return VEHICLE_REACHABILITY_LIKELY_ASLEEP
         return VEHICLE_REACHABILITY_AWAKE
+
+    @property
+    def data_freshness(self) -> str | None:
+        """How current the data from the most recent poll was (#238).
+
+        A separate axis from vehicle_reachability:
+        - live:   the poll returned a status whose timestamp advanced (proof of
+                  live contact with the car).
+        - cached: the poll succeeded but SAIC served the same, unchanged status
+                  (the car is asleep / not reporting fresh data).
+        - failed: the poll errored (e.g. a transient "return code 4").
+
+        None until the first poll cycle completes.
+        """
+        return self._last_poll_result
 
     def record_command_error(self, source: str, error: Exception | str) -> None:
         """Record a generic command failure via the command-error Event entity.

--- a/custom_components/mg_saic/event.py
+++ b/custom_components/mg_saic/event.py
@@ -56,10 +56,11 @@ def _humanize_source(source: str) -> str:
 
 
 def _humanize_command_error(source: str, error: str) -> dict:
-    """Build friendly, Logbook-ready attributes from a raw command failure.
+    """Build Logbook-ready attributes from a raw command failure.
 
-    Keeps the raw error under `detail` for debugging, but leads with a readable
-    `action` and `reason` (and a parsed `code` where available).
+    Backward-compatible: the original `source` and `error` keys are preserved
+    (this event entity has existed since 1.0.5, so automations may read them),
+    and the friendly `action`/`reason`/`code` keys are added alongside.
     """
     raw = str(error)
     low = raw.lower()
@@ -82,10 +83,15 @@ def _humanize_command_error(source: str, error: str) -> dict:
     else:
         reason = "The command could not be completed. Please try again."
 
-    attrs = {"action": _humanize_source(source), "reason": reason}
+    # Original keys kept for backward compatibility; friendly keys added.
+    attrs = {
+        "source": source,
+        "error": raw,
+        "action": _humanize_source(source),
+        "reason": reason,
+    }
     if code is not None:
         attrs["code"] = code
-    attrs["detail"] = raw
     return attrs
 
 
@@ -178,14 +184,19 @@ class SAICMGCommandErrorEvent(CoordinatorEntity, EventEntity):
             source: short identifier of which command triggered the limit,
                 e.g. "climate.set_hvac_mode"
         """
+        limit_message = (
+            "Vehicle reached the maximum number of remote commands. "
+            "Start the vehicle with the physical key to reset."
+        )
         self._trigger_event(
             EVENT_TYPE_COMMAND_LIMIT_REACHED,
             {
+                # Original keys kept for backward compatibility.
+                "source": source,
+                "message": limit_message,
+                # Friendly keys, consistent with command_error.
                 "action": _humanize_source(source),
-                "reason": (
-                    "Vehicle reached the maximum number of remote commands. "
-                    "Start the vehicle with the physical key to reset."
-                ),
+                "reason": limit_message,
                 "code": 8,
             },
         )

--- a/custom_components/mg_saic/event.py
+++ b/custom_components/mg_saic/event.py
@@ -2,7 +2,8 @@
 
 from homeassistant.components.event import EventEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN, LOGGER
+import re
+from .const import DOMAIN, LOGGER, SAIC_RETURN_CODE_UNREACHABLE
 from .utils import create_device_info
 
 # Event types this entity can fire. Only types listed here may be triggered —
@@ -15,6 +16,77 @@ EVENT_TYPES = [
     EVENT_TYPE_COMMAND_ERROR,
     EVENT_TYPE_COMMAND_LIMIT_REACHED,
 ]
+
+# SAIC return code -> plain-English explanation, so the Logbook shows readable
+# text instead of the raw exception string.
+_RETURN_CODE_REASONS = {
+    SAIC_RETURN_CODE_UNREACHABLE: (  # 4
+        "The car couldn't be reached — it may be asleep or out of signal. "
+        "Please try again shortly."
+    ),
+    8: (
+        "The remote-command limit was reached. Start the car with the physical "
+        "key to reset it."
+    ),
+}
+
+
+def _extract_return_code(text: str):
+    """Pull a SAIC 'return code: N' out of an error string, if present."""
+    match = re.search(r"return code[:=]?\s*(\d+)", text.lower())
+    return int(match.group(1)) if match else None
+
+
+def _humanize_source(source: str) -> str:
+    """Turn an internal source id into a readable action label.
+
+    e.g. "Error setting HVAC mode" -> "Setting HVAC mode",
+         "service.locking_vehicle" -> "Locking vehicle",
+         "front_defrost" -> "Front defrost".
+    """
+    if not source:
+        return "Remote command"
+    text = str(source)
+    if text.lower().startswith("error "):
+        text = text[len("error "):]
+    text = text.replace("service.", "").replace(".", " ").replace("_", " ").strip()
+    if not text:
+        return "Remote command"
+    return text[:1].upper() + text[1:]
+
+
+def _humanize_command_error(source: str, error: str) -> dict:
+    """Build friendly, Logbook-ready attributes from a raw command failure.
+
+    Keeps the raw error under `detail` for debugging, but leads with a readable
+    `action` and `reason` (and a parsed `code` where available).
+    """
+    raw = str(error)
+    low = raw.lower()
+    code = _extract_return_code(raw)
+
+    if code in _RETURN_CODE_REASONS:
+        reason = _RETURN_CODE_REASONS[code]
+    elif "too frequent" in low or "maximum number of remote commands" in low:
+        code = 8
+        reason = _RETURN_CODE_REASONS[8]
+    elif "timeout" in low or "timed out" in low:
+        reason = "Timed out waiting for the SAIC servers. Please try again."
+    elif "front defrost blocked" in low:
+        reason = (
+            "Front defrost was blocked because the air conditioning is already "
+            "running."
+        )
+    elif code is not None:
+        reason = f"The command failed (SAIC code {code}). Please try again."
+    else:
+        reason = "The command could not be completed. Please try again."
+
+    attrs = {"action": _humanize_source(source), "reason": reason}
+    if code is not None:
+        attrs["code"] = code
+    attrs["detail"] = raw
+    return attrs
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -61,6 +133,7 @@ class SAICMGCommandErrorEvent(CoordinatorEntity, EventEntity):
         self._attr_unique_id = f"{entry.entry_id}_{vin}_command_errors_event"
         self._attr_icon = "mdi:alert-circle-outline"
         self._attr_event_types = EVENT_TYPES
+        self._attr_translation_key = "command_errors"
         self._device_info = create_device_info(coordinator, entry.entry_id)
 
     @property
@@ -94,7 +167,7 @@ class SAICMGCommandErrorEvent(CoordinatorEntity, EventEntity):
         """
         self._trigger_event(
             EVENT_TYPE_COMMAND_ERROR,
-            {"source": source, "error": error},
+            _humanize_command_error(source, error),
         )
         self.async_write_ha_state()
 
@@ -108,11 +181,12 @@ class SAICMGCommandErrorEvent(CoordinatorEntity, EventEntity):
         self._trigger_event(
             EVENT_TYPE_COMMAND_LIMIT_REACHED,
             {
-                "source": source,
-                "message": (
+                "action": _humanize_source(source),
+                "reason": (
                     "Vehicle reached the maximum number of remote commands. "
                     "Start the vehicle with the physical key to reset."
                 ),
+                "code": 8,
             },
         )
         self.async_write_ha_state()

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -1,6 +1,7 @@
 # File: sensor.py
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.const import (
     PERCENTAGE,
@@ -20,6 +21,9 @@ from .const import (
     VEHICLE_REACHABILITY_AWAKE,
     VEHICLE_REACHABILITY_LIKELY_ASLEEP,
     VEHICLE_REACHABILITY_UNREACHABLE,
+    DATA_FRESHNESS_LIVE,
+    DATA_FRESHNESS_CACHED,
+    DATA_FRESHNESS_FAILED,
     PRESSURE_TO_BAR,
     DATA_DECIMAL_CORRECTION,
     DATA_DECIMAL_CORRECTION_SOC,
@@ -602,6 +606,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
         # Add sensors
         sensors.append(SAICMGVehicleReachabilitySensor(coordinator, entry, vin_info, vin_info.vin))
+        sensors.append(SAICMGDataFreshnessSensor(coordinator, entry, vin_info, vin_info.vin))
 
         async_add_entities(sensors, update_before_add=True)
 
@@ -2797,4 +2802,66 @@ class SAICMGVehicleReachabilitySensor(CoordinatorEntity, SensorEntity):
             attrs["data_age_hours"] = round(age.total_seconds() / 3600, 1)
         attrs["holiday_mode"] = bool(getattr(self.coordinator, "holiday_mode", False))
 
+        return attrs
+
+
+class SAICMGDataFreshnessSensor(CoordinatorEntity, SensorEntity):
+    """Diagnostic sensor showing how current the last poll's data was (#238).
+
+    A separate axis from the Reachability sensor: Reachability describes the
+    car's state (awake / likely_asleep / unreachable), while this describes the
+    data's state. The car can be reachable yet still return cached data.
+
+    States: live / cached / failed. See coordinator.data_freshness.
+    """
+
+    _attr_icon = "mdi:database-clock-outline"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    # Raw state values stay lowercase snake_case (automations/templates match on
+    # them); translations/<lang>.json -> entity.sensor.data_freshness provides
+    # the friendly display labels.
+    _attr_translation_key = "data_freshness"
+    _attr_options = [
+        DATA_FRESHNESS_LIVE,
+        DATA_FRESHNESS_CACHED,
+        DATA_FRESHNESS_FAILED,
+    ]
+
+    def __init__(self, coordinator, entry, vin_info, vin):
+        """Initialize the data freshness sensor."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_name = f"{vin_info.brandName} {vin_info.modelName} Data Freshness"
+        self._attr_unique_id = f"{entry.entry_id}_{vin}_data_freshness"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return self._device_info
+
+    @property
+    def available(self):
+        """Always available.
+
+        Like the Reachability sensor, this must keep reporting precisely when
+        polls are failing — that's when its 'failed' state is most useful — so
+        it never goes unavailable alongside the telemetry sensors.
+        """
+        return True
+
+    @property
+    def native_value(self):
+        """Return the freshness of the most recent poll (or None before the
+        first cycle completes)."""
+        return self.coordinator.data_freshness
+
+    @property
+    def extra_state_attributes(self):
+        """When the current data was last refreshed — supporting evidence."""
+        attrs = {}
+        last_update = getattr(self.coordinator, "last_update_time", None)
+        if last_update is not None:
+            attrs["last_update"] = last_update.isoformat()
         return attrs

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -406,6 +406,25 @@
           "likely_asleep": "Likely asleep",
           "unreachable": "Unreachable"
         }
+      },
+      "data_freshness": {
+        "state": {
+          "live": "Live",
+          "cached": "Cached",
+          "failed": "Failed"
+        }
+      }
+    },
+    "event": {
+      "command_errors": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "command_error": "Command failed",
+              "command_limit_reached": "Command limit reached"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -405,6 +405,25 @@
           "likely_asleep": "Probablemente dormido",
           "unreachable": "Inaccesible"
         }
+      },
+      "data_freshness": {
+        "state": {
+          "live": "En directo",
+          "cached": "En caché",
+          "failed": "Con error"
+        }
+      }
+    },
+    "event": {
+      "command_errors": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "command_error": "Comando fallido",
+              "command_limit_reached": "Límite de comandos alcanzado"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -406,6 +406,25 @@
           "likely_asleep": "Probablement en veille",
           "unreachable": "Injoignable"
         }
+      },
+      "data_freshness": {
+        "state": {
+          "live": "En direct",
+          "cached": "En cache",
+          "failed": "Échec"
+        }
+      }
+    },
+    "event": {
+      "command_errors": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "command_error": "Échec de la commande",
+              "command_limit_reached": "Limite de commandes atteinte"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -406,6 +406,25 @@
           "likely_asleep": "Provavelmente adormecido",
           "unreachable": "Inacessível"
         }
+      },
+      "data_freshness": {
+        "state": {
+          "live": "Em direto",
+          "cached": "Em cache",
+          "failed": "Falhou"
+        }
+      }
+    },
+    "event": {
+      "command_errors": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "command_error": "Comando falhou",
+              "command_limit_reached": "Limite de comandos atingido"
+            }
+          }
+        }
       }
     }
   }

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -923,7 +923,9 @@ class TestCommandErrorHumanizer(unittest.TestCase):
         self.assertEqual(a["code"], 4)
         self.assertIn("couldn't be reached", a["reason"])
         self.assertEqual(a["action"], "Setting HVAC mode")
-        self.assertIn("return code: 4", a["detail"])  # raw kept for debugging
+        # Original keys preserved for backward compatibility.
+        self.assertEqual(a["source"], "Error setting HVAC mode")
+        self.assertIn("return code: 4", a["error"])
 
     def test_limit_reached_maps_to_code_8(self):
         a = EVENT._humanize_command_error("climate", "operation too frequent")
@@ -939,4 +941,5 @@ class TestCommandErrorHumanizer(unittest.TestCase):
         a = EVENT._humanize_command_error("Error opening boot", "weird backend text")
         self.assertNotIn("code", a)
         self.assertIn("could not be completed", a["reason"])
-        self.assertEqual(a["detail"], "weird backend text")
+        # Raw error still available under the original key.
+        self.assertEqual(a["error"], "weird backend text")

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -125,6 +125,10 @@ def _install_stubs():
     uc.CoordinatorEntity = _DataUpdateCoordinator
     sys.modules["homeassistant.helpers.update_coordinator"] = uc
 
+    ev = types.ModuleType("homeassistant.components.event")
+    ev.EventEntity = object
+    sys.modules["homeassistant.components.event"] = ev
+
     # Minimal voluptuous stand-in: enough for schema construction at import
     # and step execution time.
     vol = types.ModuleType("voluptuous")
@@ -168,6 +172,7 @@ _load("mg_saic.backends", PKG_DIR / "backends" / "__init__.py")
 sys.modules["mg_saic.backends"].__path__ = [str(PKG_DIR / "backends")]
 _load("mg_saic.backends.india", PKG_DIR / "backends" / "india.py")
 _load("mg_saic.utils", PKG_DIR / "utils.py")
+EVENT = _load("mg_saic.event", PKG_DIR / "event.py")
 _load("mg_saic.coordinator", PKG_DIR / "coordinator.py", force=True)
 _load("mg_saic.message_poller", PKG_DIR / "message_poller.py", force=True)
 _load("mg_saic.services", PKG_DIR / "services.py", force=True)
@@ -790,6 +795,7 @@ class TestFailedCycleFastRetry(unittest.TestCase):
         c.update_interval = update_interval
         c.default_update_interval = default_interval or timedelta(hours=6)
         c.failure_retry_interval = mod.UPDATE_INTERVAL_AFTER_FAILURE
+        c._last_poll_result = None
         c._consecutive_update_failures = 0
         return c, mod
 
@@ -857,3 +863,80 @@ class TestFailedCycleFastRetry(unittest.TestCase):
             _run(c._async_update_data())
         self.assertEqual(c.update_interval, idle)
         self.assertEqual(c._consecutive_update_failures, max_fast + 1)
+
+
+# ── #238: Data Freshness sensor state ────────────────────────────────────────
+
+
+class TestDataFreshness(unittest.TestCase):
+    """coordinator.data_freshness reflects the last poll's outcome."""
+
+    def _coord(self):
+        from datetime import timedelta
+
+        mod = sys.modules["mg_saic.coordinator"]
+        c = mod.SAICMGDataUpdateCoordinator.__new__(mod.SAICMGDataUpdateCoordinator)
+        c.vin = "TESTVIN"
+        c.update_interval = timedelta(hours=6)
+        c.default_update_interval = timedelta(hours=6)
+        c.failure_retry_interval = mod.UPDATE_INTERVAL_AFTER_FAILURE
+        c._consecutive_update_failures = 0
+        c._last_poll_result = None
+        return c, mod
+
+    def test_property_reflects_last_poll_result(self):
+        c, mod = self._coord()
+        self.assertIsNone(c.data_freshness)
+        c._last_poll_result = mod.DATA_FRESHNESS_LIVE
+        self.assertEqual(c.data_freshness, "live")
+
+    def test_failed_cycle_sets_freshness_failed(self):
+        c, mod = self._coord()
+
+        async def _boom():
+            raise Exception("return code 4")
+
+        c._run_update_cycle = _boom
+        with self.assertRaises(Exception):
+            _run(c._async_update_data())
+        self.assertEqual(c.data_freshness, mod.DATA_FRESHNESS_FAILED)
+
+
+# ── Command-error event: friendly, Logbook-ready text ────────────────────────
+
+
+class TestCommandErrorHumanizer(unittest.TestCase):
+    """Raw command failures are turned into readable action/reason/code."""
+
+    def test_source_is_cleaned(self):
+        h = EVENT._humanize_source
+        self.assertEqual(h("Error setting HVAC mode"), "Setting HVAC mode")
+        self.assertEqual(h("service.locking_vehicle"), "Locking vehicle")
+        self.assertEqual(h("front_defrost"), "Front defrost")
+        self.assertEqual(h(""), "Remote command")
+
+    def test_code_4_is_unreachable(self):
+        a = EVENT._humanize_command_error(
+            "Error setting HVAC mode",
+            "return code: 4, message: The remote control instruction failed",
+        )
+        self.assertEqual(a["code"], 4)
+        self.assertIn("couldn't be reached", a["reason"])
+        self.assertEqual(a["action"], "Setting HVAC mode")
+        self.assertIn("return code: 4", a["detail"])  # raw kept for debugging
+
+    def test_limit_reached_maps_to_code_8(self):
+        a = EVENT._humanize_command_error("climate", "operation too frequent")
+        self.assertEqual(a["code"], 8)
+        self.assertIn("remote-command limit", a["reason"])
+
+    def test_timeout_reason(self):
+        a = EVENT._humanize_command_error("lock", "Connection timed out")
+        self.assertNotIn("code", a)
+        self.assertIn("Timed out", a["reason"])
+
+    def test_unknown_error_gets_generic_reason(self):
+        a = EVENT._humanize_command_error("Error opening boot", "weird backend text")
+        self.assertNotIn("code", a)
+        self.assertIn("could not be completed", a["reason"])
+        self.assertEqual(a["detail"], "weird backend text")


### PR DESCRIPTION
Two related clarity improvements, suggested by @HarryFlatter on #238.

Data Freshness sensor:
- New diagnostic sensor (entity_category: diagnostic) with states live / cached / failed, kept separate from Reachability on purpose: Reachability = the car's state (awake/asleep/unreachable), Data Freshness = the data's state (was the last poll genuinely fresh, merely cached, or a failure). The car can be reachable yet still return cached data.
- Coordinator records _last_poll_result each cycle: live/cached where fresh_status is already computed (statusTime advanced vs unchanged), and failed in the update wrapper's except branch. Exposed via a data_freshness property. Sensor is always-available (like Reachability) so it can report 'failed' instead of vanishing with the telemetry sensors.

Command-error events now read as plain English:
- The Command Errors event entity previously emitted the raw exception string (source/error). It now emits action (readable), reason (plain English, mapped from the SAIC return code — code 4 unreachable, code 8 limit, timeouts, defrost-blocked), code (parsed), and detail (raw string kept for debugging). Added a translation_key so the event_type also shows a friendly label.

- Translations for en/es/fr/pt (data_freshness states + command_errors event labels).
- README: Data Freshness sensor section + updated Command Errors docs.
- 7 new tests (freshness property/failed-state + humanizer). Suite 81 green.

### Readable command-error events (backward-compatible)
The Command Errors event entity kept its original `source`/`error` (and `message`) attributes and now *also* emits friendly `action`/`reason`/`code` — mapped from the SAIC return code (4 = unreachable, 8 = limit, plus timeouts / defrost-blocked). Nothing renamed, so no automations break. Added a `translation_key` so the event type shows a friendly label too.