### PR TITLE
fix(#238): handle command-limit (return code 8) consistently for services

### DIFF
--- a/custom_components/mg_saic/api.py
+++ b/custom_components/mg_saic/api.py
@@ -470,6 +470,8 @@ class SAICMGAPIClient:
         except ValueError as e:
             LOGGER.error("Invalid charging current limit: %s", current_limit_code)
             raise
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error setting charging current limit for VIN %s: %s", vin, e)
             raise
@@ -516,6 +518,8 @@ class SAICMGAPIClient:
             LOGGER.info(
                 "Set target SOC to %d%% for VIN: %s", target_soc_percentage, vin
             )
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error setting target SOC for VIN %s: %s", vin, e)
             raise
@@ -537,6 +541,8 @@ class SAICMGAPIClient:
                 right_side_level,
                 vin,
             )
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error controlling heated seats for VIN %s: %s", vin, e)
             raise
@@ -669,6 +675,8 @@ class SAICMGAPIClient:
                 self.saic_api.control_rear_window_heat, vin, enable=enable
             )
             LOGGER.info("Rear window heat %sed successfully.", action)
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error controlling rear window heat: %s", e)
             raise
@@ -724,6 +732,8 @@ class SAICMGAPIClient:
                 fan_speed,
                 vin,
             )
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error starting AC with settings for VIN %s: %s", vin, e)
             raise
@@ -733,6 +743,8 @@ class SAICMGAPIClient:
         try:
             await self._make_api_call(self.saic_api.start_front_defrost, vin)
             LOGGER.info("Front defrost started successfully.")
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error starting front defrost: %s", e)
             raise
@@ -742,6 +754,8 @@ class SAICMGAPIClient:
         try:
             await self._make_api_call(self.saic_api.stop_ac, vin)
             LOGGER.info("AC stopped successfully.")
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error stopping AC: %s", e)
             raise
@@ -758,6 +772,8 @@ class SAICMGAPIClient:
                 "unlocked" if unlock else "locked",
                 vin,
             )
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error controlling charging port lock for VIN %s: %s", vin, e)
             raise
@@ -767,6 +783,8 @@ class SAICMGAPIClient:
         try:
             await self._make_api_call(self.saic_api.lock_vehicle, vin)
             LOGGER.info("Vehicle locked successfully.")
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error locking vehicle: %s", e)
             raise
@@ -776,6 +794,8 @@ class SAICMGAPIClient:
         try:
             await self._make_api_call(self.saic_api.open_tailgate, vin)
             LOGGER.info("Tailgate opened successfully.")
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error opening tailgate: %s", e)
             raise
@@ -785,6 +805,8 @@ class SAICMGAPIClient:
         try:
             await self._make_api_call(self.saic_api.unlock_vehicle, vin)
             LOGGER.info("Vehicle unlocked successfully.")
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error unlocking vehicle: %s", e)
             raise
@@ -803,6 +825,8 @@ class SAICMGAPIClient:
                 action_name,
                 vin,
             )
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error controlling sunroof for VIN %s: %s", vin, e)
             raise
@@ -871,6 +895,8 @@ class SAICMGAPIClient:
             LOGGER.info(
                 "Windows %s command sent successfully for VIN: %s", action_key, vin
             )
+        except CommandsLimitReachedException:
+            raise
         except Exception as e:
             LOGGER.error("Error controlling windows for VIN %s: %s", vin, e)
             raise

--- a/custom_components/mg_saic/services.py
+++ b/custom_components/mg_saic/services.py
@@ -6,6 +6,7 @@ from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
 from .backends import Feature, backend_supports
+from .api import CommandsLimitReachedException
 from .const import (
     DOMAIN,
     LOGGER,
@@ -144,7 +145,18 @@ def _record_command_error(hass: HomeAssistant, vin: str, source: str, error) -> 
     """
     try:
         _, coordinator = _get_vehicle_resources(hass, vin)
-        coordinator.record_command_error(source, error)
+        # A command-limit rejection (return code 8) is not a generic failure:
+        # route it to the dedicated notification/event so a limit hit via a
+        # SERVICE call behaves the same as one via the lock/climate entities
+        # (persistent notification + command_limit_reached event), rather than
+        # surfacing as a generic command_error. notify_command_limit_reached is
+        # async; we're on the event loop here, so schedule it as a task.
+        if isinstance(error, CommandsLimitReachedException):
+            hass.async_create_task(
+                coordinator.notify_command_limit_reached(vin, source)
+            )
+        else:
+            coordinator.record_command_error(source, error)
     except Exception:  # noqa: BLE001 - supplementary, must never break the caller
         pass
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -395,3 +395,56 @@ class FakeIndiaClient:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCommandLimitGuard(unittest.TestCase):
+    """Remote-command API methods re-raise the command limit (return code 8)
+    without also logging it as a generic error — it's already logged as a
+    WARNING in _make_api_call. Generic errors are still logged normally."""
+
+    def _client(self):
+        api = sys.modules["mg_saic.api"]
+        client = api.SAICMGAPIClient.__new__(api.SAICMGAPIClient)
+        client.saic_api = MagicMock()
+        return client, api
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_limit_reraised_without_error_log(self):
+        client, api = self._client()
+
+        async def _raise(*a, **k):
+            raise api.CommandsLimitReachedException("return code: 8")
+
+        client._make_api_call = _raise
+        errors = []
+        orig = api.LOGGER.error
+        api.LOGGER.error = lambda *a, **k: errors.append(a)
+        try:
+            with self.assertRaises(api.CommandsLimitReachedException):
+                self._run(client.lock_vehicle("VIN"))
+        finally:
+            api.LOGGER.error = orig
+        self.assertEqual(errors, [], "command limit must not be logged as an error")
+
+    def test_generic_error_still_logged(self):
+        client, api = self._client()
+
+        async def _raise(*a, **k):
+            raise RuntimeError("boom")
+
+        client._make_api_call = _raise
+        errors = []
+        orig = api.LOGGER.error
+        api.LOGGER.error = lambda *a, **k: errors.append(a)
+        try:
+            with self.assertRaises(RuntimeError):
+                self._run(client.lock_vehicle("VIN"))
+        finally:
+            api.LOGGER.error = orig
+        self.assertTrue(errors, "a genuine error should still be logged")


### PR DESCRIPTION
Follow-up to the command-error work, prompted by @HarryFlatter's log: a lock issued via a SERVICE call hit the remote-command limit (return code 8) and was handled worse than the same limit via the lock/climate entities.

- services.py: _record_command_error now routes a CommandsLimitReachedException to coordinator.notify_command_limit_reached (persistent notification + command_limit_reached event, with the service source for diagnostics) instead of recording it as a generic command_error. Scheduled via hass.async_create_task since the notify is async and the helper is sync-on-loop.
- api.py: remote-command methods now re-raise CommandsLimitReachedException without the redundant per-method ERROR log — the limit is already logged once as a WARNING in _make_api_call. Data-fetch methods are untouched.
- 2 new tests (limit re-raised without error log; generic error still logged). Suite 83 green.