### PR TITLE
fix(sensor): don't create charging-endpoint sensors for HEV (issue #258)

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.0-beta3"
+  "version": "1.2.0-beta4"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -312,10 +312,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 ),
             )
 
-            # SOC and battery capacity are sourced from the charging endpoint,
-            # which not every backend provides (MG India has no charging data)
-            # — gate them separately from the status-sourced Electric Range.
-            if coordinator.backend_supports(Feature.CHARGING_DATA):
+            # SOC and battery capacity are sourced from the charging endpoint.
+            # The coordinator only fetches that endpoint for BEV/PHEV — never
+            # for HEV, because a full (non-plug-in) hybrid has no externally
+            # reported traction-battery charging data (see the fetch gate in
+            # coordinator.py: vehicle_type in ["BEV", "PHEV"]). Creating these
+            # two sensors for an HEV therefore produced permanently-unavailable
+            # entities that also logged "No charging data available for ..." as
+            # an ERROR on *every* poll (issue #258 — MG3 Hybrid, series ZP22).
+            # Mirror the coordinator's own gate here so sensor creation matches
+            # data availability. The backend_supports() check is retained so the
+            # India two-backend path (which reports no charging data at all —
+            # issue #169) stays correct.
+            if vehicle_type in ["BEV", "PHEV"] and coordinator.backend_supports(
+                Feature.CHARGING_DATA
+            ):
                 sensors.append(
                     SAICMGSOCSensor(
                         coordinator,


### PR DESCRIPTION
HEV vehicles (e.g. MG3 Hybrid, series ZP22) were given SOC and Total Battery Capacity sensors gated only by backend_supports(CHARGING_DATA), but the coordinator never fetches the charging endpoint for HEV. The result was two permanently-unavailable entities plus a 'No charging data available for ...' ERROR logged on every poll.

Gate these two charging-sourced sensors on vehicle_type in [BEV, PHEV] as well, mirroring the coordinator's own charging-fetch condition. The backend_supports() check is retained so the India two-backend path (#169) is unaffected. Bumps manifest to 1.2.0-beta4.