### PR TITLE
feat(climate): add Max Cool preset for AH4EM (MG4 EV URBAN) (#243)

### DIFF
--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -114,7 +114,14 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
             self._attr_hvac_modes = hvac_modes
 
             preset_modes = [PRESET_NONE]
-            if coordinator.climate_mode_max_cool != coordinator.climate_mode_cool:
+            # Offer Max Cool either when the car has a genuinely distinct
+            # max-cool mode value, or when the profile asks Max Cool to pin the
+            # setpoint to the minimum (cars whose plain Cool is already the
+            # strongest cool — e.g. AH4EM, #243).
+            if (
+                coordinator.climate_mode_max_cool != coordinator.climate_mode_cool
+                or coordinator.max_cool_forces_min_temp
+            ):
                 preset_modes.append(PRESET_MAX_COOL)
             if coordinator.climate_status_defrost:
                 preset_modes.append(PRESET_DEFROST)
@@ -419,6 +426,15 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
         try:
             c = self.coordinator
             if preset_mode == PRESET_MAX_COOL:
+                if c.max_cool_forces_min_temp:
+                    # Mirror the iSmart app's LOW-cool button: strongest cool
+                    # mode + coldest setpoint in a single tap. Set the visible
+                    # target temperature to the profile minimum first — this is
+                    # persistent and user-intended (unlike Defrost's transient
+                    # fixed temp), so the card should reflect it — then send the
+                    # cool mode, which picks up the new setpoint via
+                    # _temperature_idx().
+                    self._attr_target_temperature = self.min_temp
                 await self._send_climate_command(
                     c.climate_mode_max_cool, HVACMode.COOL, preset=PRESET_MAX_COOL
                 )

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -234,9 +234,15 @@ VEHICLE_PROFILES = {
         "climate_mode_fan_only": 1,
         "climate_mode_cool": 3,       # only confirmed cool value on this car
         "climate_mode_defrost": 5,
-        # No climate_mode_max_cool: only mode 3 is a confirmed cool, so it is the
-        # default cool and no separate Max Cool preset is offered (see the
-        # max_cool != cool gate in climate.py). No climate_mode_heat — unconfirmed.
+        # No distinct climate_mode_max_cool: mode 3 is the only confirmed cool,
+        # so plain Cool already uses the strongest cooling this car has. The
+        # Max Cool preset is still offered via max_cool_forces_min_temp below —
+        # it sends that same cool mode but pins the target temperature to the
+        # profile minimum (17°C), mirroring the iSmart app's one-tap LOW-cool
+        # button (temperature to lowest + fan max in a single action; #243).
+        # No climate_mode_heat — unconfirmed, and this car has no heater, so a
+        # matching Max Heat is deliberately not offered here.
+        "max_cool_forces_min_temp": True,
         "climate_status_fan_only": {1},
         "climate_status_cool": {3},
         "climate_status_defrost": {5},

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -227,6 +227,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         self.climate_mode_cool: int = 2       # HVACMode.COOL (auto fan, follows temp)
         self.climate_mode_heat: int = 4       # HVACMode.HEAT
         self.climate_mode_max_cool: int = 3   # preset "Max Cool" (fixed strong fan)
+        # When True, the Max Cool preset also pins the target temperature to the
+        # profile minimum (mirrors the iSmart app's one-tap LOW-cool button).
+        # Used by cars whose plain Cool mode is already the strongest cool, so
+        # the only extra thing Max Cool adds is the coldest setpoint (e.g. the
+        # MG4 EV URBAN, AH4EM — see #243).
+        self.max_cool_forces_min_temp: bool = False
         self.climate_mode_defrost: int = 5    # preset "Defrost"
         # Reverse map: remoteClimateStatus values that mean "heating".
         # (cool/fan_only reverse maps already exist as climate_status_cool /
@@ -779,6 +785,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.climate_mode_cool = profile.get("climate_mode_cool", 2)
             self.climate_mode_heat = profile.get("climate_mode_heat", 4)
             self.climate_mode_max_cool = profile.get("climate_mode_max_cool", 3)
+            self.max_cool_forces_min_temp = profile.get(
+                "max_cool_forces_min_temp", False
+            )
             self.climate_mode_defrost = profile.get("climate_mode_defrost", 5)
             self.climate_status_heat = profile.get("climate_status_heat", set())
             self.climate_status_defrost = profile.get("climate_status_defrost", set())

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.0-beta3"
+  "version": "1.2.0-beta5"
 }


### PR DESCRIPTION
The iSmart app has a one-tap LOW-cool button that sets the coldest temperature and max fan in a single action. On the MG4 EV URBAN (mode_select, series AH4EM) plain Cool already sends the strongest cool mode (climate_mode_cool=3), so the only thing LOW adds is pinning the setpoint to the minimum.

Add a per-profile flag max_cool_forces_min_temp (default False). When set, the Max Cool preset is offered even without a distinct max-cool mode value, and selecting it sets the target temperature to the profile minimum (17°C on AH4EM) before sending the cool mode — so the card reflects the coldest setpoint and the car cools as hard as it can.

Enabled for AH4EM. Cars with a genuinely distinct max-cool mode are unaffected (flag defaults False; existing offer/behaviour unchanged). No Max Heat: AH4EM has no heater. Bumps manifest to 1.2.0-beta5.