### PR TITLE
feat(mg3): support MG3 Hybrid (ZP22) climate + windows (#258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Not all MG models expose climate control the same way, so the integration uses o
  
 - **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes (and `Heat` on models with a confirmed heater, e.g. the MG4 Electric). This is the default and covers the standard MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
 - **Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle. Available modes and presets vary by model — a car is only offered `Heat` or a `Defrost` preset if it actually supports them (the MG4 EV URBAN, for example, has no heat mode).
+- **Simple-AC models (e.g. MG3 Hybrid):** a few cars only act on the basic on/off AC command and ignore everything else, so they get a stripped-back `Cool` / `Off` climate entity with no fan slider (see below).
  
 ### How commands are used
  
@@ -293,6 +294,17 @@ Front defrost (the standalone **Front Defrost switch**, and the **Defrost preset
 
 > **Note:** `Heat` appears only on models where resistive heating has been confirmed. On the MG4 Electric it engages the PTC heater; because of how the car works, heating always runs at the top of the temperature range rather than a chosen setpoint.
  
+### Simple-AC models (MG3 Hybrid)
+
+Some cars only accept the simplest remote-AC command and silently ignore the fuller one that carries a fan speed. The **MG3 Hybrid** is the first such model: its air conditioning is controlled with a single on/off cooling action, so the integration shows a stripped-back climate entity for it:
+
+| Mode | Behaviour |
+|---|---|
+| `Cool` | Turns the air conditioning on at your chosen temperature (this is the same command the iSmart app's A/C button uses) |
+| `Off` | Turns the air conditioning off |
+
+There is **no fan-speed slider, no `Fan Only` mode, and no Front Defrost** on this model — the car doesn't act on the commands those need, so they're not shown rather than appearing to work and doing nothing. The MG3 also only reports its **driver window**, so only that one window sensor is created.
+
 ### Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN)
  
 On these models there is **no fan-speed slider** — the car manages its own fan. Control is via HVAC modes and presets instead:

--- a/custom_components/mg_saic/binary_sensor.py
+++ b/custom_components/mg_saic/binary_sensor.py
@@ -162,16 +162,25 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 "mdi:car-door",
                 "status",
             ),
-            SAICMGBinarySensor(
-                coordinator,
-                entry,
-                passenger_window_name,
-                "passengerWindow",
-                BinarySensorDeviceClass.WINDOW,
-                "mdi:car-door",
-                "status",
-            ),
         ]
+
+        # Front passenger window — suppressed on models that only track the
+        # driver window (e.g. MG3 Hybrid / ZP22: the car returns a phantom
+        # passengerWindow reading, stuck at 1, and the iSmart app itself shows
+        # only the driver window). coordinator.has_front_passenger_window comes
+        # from the per-model VEHICLE_PROFILES entry. See #258.
+        if coordinator.has_front_passenger_window:
+            binary_sensors.append(
+                SAICMGBinarySensor(
+                    coordinator,
+                    entry,
+                    passenger_window_name,
+                    "passengerWindow",
+                    BinarySensorDeviceClass.WINDOW,
+                    "mdi:car-door",
+                    "status",
+                )
+            )
 
         # Rear doors — only present on 4-door vehicles (not e.g. Cyberster EC32).
         # coordinator.has_rear_doors comes from the per-model VEHICLE_PROFILES

--- a/custom_components/mg_saic/climate.py
+++ b/custom_components/mg_saic/climate.py
@@ -136,6 +136,20 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
             )
             self._attr_fan_modes = None
             self._attr_fan_mode = None
+        elif coordinator.cool_uses_start_ac:
+            # Cars that only honour the simple start_ac command (e.g. the MG3
+            # Hybrid, series ZP22 — see #258). control_climate (with a fan
+            # byte) is silently ignored, so there's a single on/off cooling
+            # control: no fan slider, no Fan Only (it would be identical to
+            # Cool), and no Heat or Defrost (those ride on control_climate too).
+            self._attr_supported_features = (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.TURN_ON
+                | ClimateEntityFeature.TURN_OFF
+            )
+            self._attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL]
+            self._attr_fan_modes = None
+            self._attr_fan_mode = None
         else:
             # Classic fan-speed cars: Low/Med/High fan slider.
             self._attr_supported_features = (
@@ -377,12 +391,20 @@ class SAICMGClimateEntity(CoordinatorEntity, ClimateEntity):
     async def _set_hvac_fan_speed(self, hvac_mode):
         """Handle HVAC mode changes for the classic fan_speed scheme."""
         if hvac_mode == HVACMode.COOL:
-            await self._client.start_climate(
-                self._vin,
-                temperature_idx=self._temperature_idx(),
-                fan_speed=self._fan_speed_to_int(),
-                ac_on=True,
-            )
+            if self.coordinator.cool_uses_start_ac:
+                # This car ignores control_climate; start_ac (temperature only)
+                # is the only command it acts on (#258).
+                await self._client.start_ac(
+                    vin=self._vin,
+                    temperature_idx=self._temperature_idx(),
+                )
+            else:
+                await self._client.start_climate(
+                    self._vin,
+                    temperature_idx=self._temperature_idx(),
+                    fan_speed=self._fan_speed_to_int(),
+                    ac_on=True,
+                )
         elif hvac_mode == HVACMode.HEAT:
             # PTC resistive heating (e.g. MG4). Confirmed from decrypted iSmart
             # traffic (#173): the heater engages only with the compressor OFF

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -157,6 +157,28 @@ CHARGING_VOLTAGE_FACTOR = 0.25
 # electrive.com, and Carwow (77 kWh gross / 74.3 kWh usable, same across
 # single-motor Long Range and Dual Motor variants).
 VEHICLE_PROFILES = {
+    "ZP22": {  # MG3 Hybrid (HEV) — see #258
+        "min_temp": 16,
+        "max_temp": 28,
+        "temp_offset": 2,
+        "battery_capacity_kwh": None,
+        # This car only honours the SIMPLE start_ac command (temperature only).
+        # The full control_climate command (with the fan-speed byte) — which
+        # both "Cool" and "Front Defrost" ride on — is silently ignored: the car
+        # echoes remoteClimateStatus=3 (or stays 0 for defrost) but never
+        # actions it. Confirmed from user HVAC tests + logs (#258). So route
+        # Cool via start_ac, drop the fan slider, and don't offer Front Defrost.
+        "cool_uses_start_ac": True,
+        "has_front_defrost": False,
+        # The car tracks only the driver window. passengerWindow comes back a
+        # phantom (stuck =1) and there are no real rear-window sensors — the
+        # iSmart app itself shows only the driver window (WINDOW bitmask 1000).
+        "has_front_passenger_window": False,
+        "has_rear_windows": False,
+        # HEV (no plug) → no Target SOC. Also already gated by vehicle_type,
+        # but set explicitly so the profile is self-describing.
+        "supports_target_soc": False,
+    },
     "EH32": {  # MG4 Electric
         "min_temp": 17,
         "max_temp": 33,

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -391,6 +391,16 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # before _update_state runs.
         self.has_rear_doors = True
         self.has_rear_windows = True
+        # Front passenger window / front defrost are present on all normally
+        # profiled cars; a per-model profile can turn them off (e.g. the MG3
+        # Hybrid tracks only the driver window and ignores the defrost command
+        # — see #258).
+        self.has_front_passenger_window = True
+        self.has_front_defrost = True
+        # When True, the fan-speed "Cool" mode is sent via the simple start_ac
+        # command instead of the full control_climate command (for cars that
+        # only honour start_ac — e.g. the MG3 Hybrid, #258).
+        self.cool_uses_start_ac = False
 
         # Post-shutdown refresh sequence — enabled by default, opt-out via options.
         # When enabled, the coordinator fires a rapid series of refreshes after
@@ -803,6 +813,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             # rear doors/windows) for any unprofiled or 4-door/4-window car.
             self.has_rear_doors = profile.get("has_rear_doors", True)
             self.has_rear_windows = profile.get("has_rear_windows", True)
+            self.has_front_passenger_window = profile.get(
+                "has_front_passenger_window", True
+            )
+            self.has_front_defrost = profile.get("has_front_defrost", True)
+            self.cool_uses_start_ac = profile.get("cool_uses_start_ac", False)
 
             LOGGER.debug(
                 "Vehicle series detected: %s (profile: %s). "

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.0-beta5"
+  "version": "1.2.0-beta6"
 }

--- a/custom_components/mg_saic/switch.py
+++ b/custom_components/mg_saic/switch.py
@@ -28,8 +28,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     switches = []
 
-    # Front Defrost Switch (backend-gated; not confirmed for all backends)
-    if coordinator.backend_supports(Feature.FRONT_DEFROST):
+    # Front Defrost Switch (backend-gated; not confirmed for all backends).
+    # Also suppressed per-model when the car ignores the defrost command: the
+    # MG3 Hybrid (#258) only honours start_ac and silently drops the
+    # control_climate command that front defrost rides on.
+    if coordinator.has_front_defrost and coordinator.backend_supports(
+        Feature.FRONT_DEFROST
+    ):
         switches.append(
             SAICMGFrontDefrostSwitch(coordinator, client, entry, vin_info, vin)
         )


### PR DESCRIPTION
The MG3 Hybrid only acts on the simple start_ac command; the full control_climate command (with a fan-speed byte) is silently ignored — it echoes remoteClimateStatus 3 (or stays 0 for defrost) but does nothing physically. Confirmed from user HVAC tests + logs.

- Add MG3 (series ZP22) vehicle profile.
- New per-profile flag cool_uses_start_ac: routes the fan-speed Cool mode via start_ac instead of control_climate. On such cars the climate entity shows only Cool/Off, no fan slider (no Fan Only, Heat, Defrost).
- New flag has_front_defrost (default True): suppresses the Front Defrost switch for the MG3 (rides on the ignored control_climate command).
- New flag has_front_passenger_window (default True): the MG3 tracks only the driver window; passengerWindow is a phantom (stuck =1) and there are no real rear-window sensors (has_rear_windows also False).

All flags default to existing behaviour, so no other model is affected. README updated with a 'Simple-AC models' section. Bumps to 1.2.0-beta6.