### PR TITLE
Feat/voice climate controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,13 @@ Home Assistant's voice assistants, the MCP bridge, and some automations can only
 - **Air Conditioning** *(switch)* — turns the AC on/off. This is the one an assistant can toggle by voice. Turning it **on runs the AC at whatever temperature is currently set** — it does not force a hot/cold extreme.
 - **Climate Target Temperature** *(number)* — the setpoint as a plain number. Display-only, exactly like the climate slider: changing it never sends a command; it rides along with the next AC command.
 - **Climate Mode** *(select)* — `Off` / `Cool` / `Fan Only` (and `Heat` where supported). Not shown on simple-AC models that only have `Cool`.
-- **Climate Mode** *(sensor)* — a detailed read-back of the mode the car is actually running (`off` / `cool` / `fan_only` / `heat` / `defrost`), so an assistant or automation can confirm the result — more than the simple on/off HVAC Status.
+- **Climate Mode** *(sensor)* — a detailed read-back of the mode the car is actually running (`off` / `cool` / `fan_only` / `heat` / `defrost`), so an assistant or automation can confirm the result — more than the simple on/off HVAC Status. It also reports **On (under car control)** when the car's climate is running under **local** control (i.e. you're driving with it on from the dashboard) rather than from a remote command — see below.
 
 All of these mirror the climate entity, so you can mix and match: set the temperature with the number, turn it on with the switch, and read the result from the sensor. The 3-command limit still applies — only turning the AC on/off or changing mode sends a command.
 
 > **Setting a specific temperature:** the AC on/off switch (and the climate power button) run the AC at the **currently set temperature**. The `Cool` and `Heat` *modes* carry their own temperature — on simple-AC models like the MG3, `Cool` goes to the coldest setting and `Heat` to the warmest. So if you want a temperature **between** the extremes, **set the temperature first, then turn the AC on with the switch** — that pushes your chosen value. Using the `Cool`/`Heat` mode instead will move to the min/max end.
+
+> **Climate under local control (while driving):** if you're driving with the climate on from the car's own dashboard, the car reports it as running under *local* control. The remote controls — the climate entity, the A/C switch and the Climate Mode select — represent what Home Assistant is *commanding*, so they stay **Off** in this case (there's no active remote command). Only the **Climate Mode sensor** reflects the physical reality, showing **On (under car control)**. This is also why the car's own dashboard temperature isn't shown while driving: SAIC doesn't report the car's live setpoint, so Home Assistant only ever shows the temperature *you've* set.
 
 ### Front defrost behaviour
  

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1915,9 +1915,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         """Decode remoteClimateStatus into a mode string.
 
         Returns one of "off", "cool", "fan_only", "heat", "defrost",
-        "unknown", or None when no status is available. Uses the same
-        per-model reverse maps the climate entity uses, so the A/C switch and
-        the Climate Mode sensor agree with the climate entity's hvac_mode.
+        "on_local", "unknown", or None when no status is available. Uses the
+        same per-model reverse maps the climate entity uses, so the A/C switch
+        and the Climate Mode sensor agree with the climate entity's hvac_mode.
         """
         s = self.current_remote_climate_status
         if s is None:
@@ -1932,6 +1932,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             return "fan_only"
         if s == 0:
             return "off"
+        if s == 6:
+            # 6 = the climate is running under LOCAL control — i.e. the driver
+            # is operating it from the dashboard (typically while driving), not
+            # a remote command. Confirmed SAIC-wide, not tied to a profile.
+            return "on_local"
         return "unknown"
 
     @property

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.0-beta8"
+  "version": "1.2.0-beta9"
 }

--- a/custom_components/mg_saic/select.py
+++ b/custom_components/mg_saic/select.py
@@ -457,17 +457,19 @@ class SAICMGClimateModeSelect(CoordinatorEntity, SelectEntity):
 
     @property
     def current_option(self):
-        """Reflect the car's actual climate mode."""
-        mode = self.coordinator.climate_mode_from_status()
+        """Reflect the climate entity's reconciled mode, so the select never
+        disagrees with it (unlike decoding the raw status separately, which
+        showed no selection whenever the car reported an unmapped status)."""
+        climate = self.coordinator.climate_entity
+        if climate is None:
+            return None
         mapping = {
-            "off": "Off",
-            "cool": "Cool",
-            # Defrost is layered on top of active cooling; report Cool as the base.
-            "defrost": "Cool",
-            "fan_only": "Fan Only",
-            "heat": "Heat",
+            HVACMode.OFF: "Off",
+            HVACMode.COOL: "Cool",
+            HVACMode.FAN_ONLY: "Fan Only",
+            HVACMode.HEAT: "Heat",
         }
-        opt = mapping.get(mode)
+        opt = mapping.get(climate.hvac_mode)
         return opt if opt in self._attr_options else None
 
     async def async_select_option(self, option):

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2892,7 +2892,10 @@ class SAICMGClimateModeSensor(CoordinatorEntity, SensorEntity):
 
     _attr_icon = "mdi:air-conditioner"
     _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = ["off", "cool", "fan_only", "heat", "defrost", "unknown"]
+    # Lets Home Assistant translate the raw (lowercase snake_case) state values
+    # into friendly labels via translations/<lang>.json -> entity.sensor.
+    _attr_translation_key = "climate_mode"
+    _attr_options = ["off", "cool", "fan_only", "heat", "defrost", "on_local", "unknown"]
 
     def __init__(self, coordinator, entry, vin_info, vin):
         """Initialize the Climate Mode sensor."""

--- a/custom_components/mg_saic/switch.py
+++ b/custom_components/mg_saic/switch.py
@@ -974,11 +974,18 @@ class SAICMGACSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self):
-        """Whether the car's A/C is currently running (from remoteClimateStatus)."""
-        mode = self.coordinator.climate_mode_from_status()
-        if mode is None:
+        """Whether the A/C is on.
+
+        Mirror the climate entity's reconciled hvac_mode rather than decoding
+        remoteClimateStatus independently, so the switch can never disagree
+        with the climate entity. (Decoding the raw status separately made the
+        switch read "on" whenever the car reported a status we don't map — e.g.
+        while the car is being driven — while the climate entity read Off.)
+        """
+        climate = self.coordinator.climate_entity
+        if climate is None:
             return None
-        return mode != "off"
+        return climate.hvac_mode != HVACMode.OFF
 
     async def async_turn_on(self, **kwargs):
         """Turn the A/C on at the current setpoint by delegating to the climate

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -425,6 +425,17 @@
           "cached": "Cached",
           "failed": "Failed"
         }
+      },
+      "climate_mode": {
+        "state": {
+          "off": "Off",
+          "cool": "Cool",
+          "fan_only": "Fan only",
+          "heat": "Heat",
+          "defrost": "Defrost",
+          "on_local": "On (under car control)",
+          "unknown": "Unknown"
+        }
       }
     },
     "event": {

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -424,6 +424,17 @@
           "cached": "En caché",
           "failed": "Con error"
         }
+      },
+      "climate_mode": {
+        "state": {
+          "off": "Apagado",
+          "cool": "Frío",
+          "fan_only": "Solo ventilador",
+          "heat": "Calor",
+          "defrost": "Descongelación",
+          "on_local": "Encendido (control del vehículo)",
+          "unknown": "Desconocido"
+        }
       }
     },
     "event": {

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -425,6 +425,17 @@
           "cached": "En cache",
           "failed": "Échec"
         }
+      },
+      "climate_mode": {
+        "state": {
+          "off": "Éteint",
+          "cool": "Refroidissement",
+          "fan_only": "Ventilation seule",
+          "heat": "Chauffage",
+          "defrost": "Dégivrage",
+          "on_local": "Activé (contrôle du véhicule)",
+          "unknown": "Inconnu"
+        }
       }
     },
     "event": {

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -425,6 +425,17 @@
           "cached": "Em cache",
           "failed": "Falhou"
         }
+      },
+      "climate_mode": {
+        "state": {
+          "off": "Desligado",
+          "cool": "Arrefecimento",
+          "fan_only": "Apenas ventilação",
+          "heat": "Aquecimento",
+          "defrost": "Descongelação",
+          "on_local": "Ligado (controlo do veículo)",
+          "unknown": "Desconhecido"
+        }
       }
     },
     "event": {


### PR DESCRIPTION
**feat(climate): voice/automation A/C controls + local-control read-back**

Adds assistant-controllable climate entities that mirror the climate entity,
plus honest handling of local (driver-operated) climate. Targets `beta`
(1.2.0-beta9). Requested in #258.

New entities (all models, gated by profile):
- switch **Air Conditioning** — on/off; runs the AC at the current setpoint.
  Delegates to the climate entity (single dispatch path).
- number **Climate Target Temperature** — setpoint, shared with the climate
  entity via `coordinator.requested_target_temp`. Display-only, no command.
- select **Climate Mode** — Off/Cool/Fan Only/[Heat]; skipped on simple-AC
  models (MG3) that only have Cool.
- sensor **Climate Mode** — decodes `remoteClimateStatus`; localised (en/es/
  fr/pt) via a translation_key.

Consistency / behaviour:
- The switch's `is_on` and the select's `current_option` mirror the climate
  entity's reconciled `hvac_mode` (not a separate raw-status decode), so the
  controls can never disagree with the climate entity.
- `async_turn_on` runs the AC at the set temperature (Cool/Heat modes carry
  their own; on the MG3, coldest/warmest).
- `remoteClimateStatus = 6` (climate running under LOCAL control) is now
  decoded to `on_local` / "On (under car control)". The remote controls stay
  Off for 6 (they represent what HA commands; no remote command is active);
  only the sensor reflects the physical state. This is why the climate entity
  can read Off while you're driving with the AC on — SAIC doesn't send the
  car's live setpoint either, so HA only shows the temperature you set.

Notes:
- Merged current `beta` in (MG3 branch had landed); resolved manifest →
  beta8, kept the A/C-switch registration + the `has_front_defrost` gating,
  and fixed two auto-merge issues in climate.py (MG3 dispatch writing the
  removed `_attr_target_temperature`; a duplicate `async_turn_on`).
- Compiles clean; translations validated. Needs the usual HA smoke test.
