### PR TITLE
fix(message-poller): vehicle-start hint no longer sets a future power-on time

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -496,6 +496,20 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             started_at: timezone-aware datetime derived from the vehicle-start
                         message.  Callers must ensure UTC-aware before passing.
         """
+        # A power-on time can never be in the future. Clamp defensively so a
+        # bad message timestamp can't poison the power-on time or the duration
+        # maths downstream, regardless of the caller.
+        now_utc = datetime.now(timezone.utc)
+        if started_at > now_utc:
+            LOGGER.debug(
+                "hint_vehicle_started: VIN %s clamping future start time "
+                "%s to now (%s)",
+                self.vin,
+                started_at,
+                now_utc,
+            )
+            started_at = now_utc
+
         # Guard: don't regress a more-recent confirmed power-on timestamp
         if (
             self.is_powered_on

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.0-beta9"
+  "version": "1.2.0-beta10"
 }

--- a/custom_components/mg_saic/message_poller.py
+++ b/custom_components/mg_saic/message_poller.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from .const import LOGGER
 
@@ -458,14 +458,21 @@ class SAICMGAccountPoller:
                 refresh_reason.append("engine start")
 
                 # ── Hint the coordinator immediately ─────────────────────────
-                # Extract start time from createTime (Unix ms) if available —
-                # it is timezone-unambiguous.  Fall back to the message_time
-                # property (naive string, treated as UTC) if createTime is None.
-                started_at: datetime | None = None
+                # The vehicle-start message is processed within one ~60s poll of
+                # the car actually starting, so "now" (UTC) is a reliable,
+                # timezone-safe anchor for the hint. We only prefer a real
+                # createTime (Unix epoch ms — timezone-unambiguous) when it's
+                # plausible. We deliberately no longer trust message_time: it's a
+                # naive server-local string that the SAIC EU backend stamps in
+                # CET/CEST (UTC+1/+2), NOT UTC — treating it as UTC put the
+                # pre-set powered-on time up to 2 hours in the FUTURE.
+                now_utc = datetime.now(timezone.utc)
+                started_at: datetime = now_utc
+                hint_source = "current time"
                 create_time_ms = getattr(msg, "createTime", None)
                 if create_time_ms is not None:
                     try:
-                        started_at = datetime.fromtimestamp(
+                        candidate = datetime.fromtimestamp(
                             create_time_ms / 1000.0, tz=timezone.utc
                         )
                     except (OSError, OverflowError, ValueError) as exc:
@@ -475,34 +482,38 @@ class SAICMGAccountPoller:
                             create_time_ms,
                             exc,
                         )
-
-                if started_at is None:
-                    # Fallback: message_time is naive (SAIC server local time,
-                    # empirically close to UTC for EU region).  Attach UTC to
-                    # avoid comparison errors — this is a best-effort hint.
-                    raw_mt = getattr(msg, "message_time", None)
-                    if raw_mt is not None:
-                        try:
-                            if raw_mt.tzinfo is None:
-                                started_at = raw_mt.replace(tzinfo=timezone.utc)
-                            else:
-                                started_at = raw_mt
-                        except Exception as exc:
+                    else:
+                        # Accept createTime only if it's plausible: recent and
+                        # not in the future. Otherwise fall back to "now".
+                        if (
+                            now_utc - timedelta(hours=6)
+                            <= candidate
+                            <= now_utc + timedelta(minutes=1)
+                        ):
+                            started_at = candidate
+                            hint_source = "createTime"
+                        else:
                             LOGGER.debug(
-                                "AccountPoller %s: could not attach tz to "
-                                "message_time: %s",
+                                "AccountPoller %s: createTime %s implausible "
+                                "(now %s) — using current time for the hint",
                                 self._account_key,
-                                exc,
+                                candidate,
+                                now_utc,
                             )
 
-                if started_at is not None and hasattr(coordinator, "hint_vehicle_started"):
+                # Final safety net: a power-on time must never be in the future.
+                if started_at > now_utc:
+                    started_at = now_utc
+                    hint_source = "current time"
+
+                if hasattr(coordinator, "hint_vehicle_started"):
                     LOGGER.info(
                         "AccountPoller %s: hinting VIN %s started at %s "
                         "(from %s)",
                         self._account_key,
                         vin,
                         started_at,
-                        "createTime" if create_time_ms is not None else "message_time",
+                        hint_source,
                     )
                     coordinator.hint_vehicle_started(started_at)
                 else:


### PR DESCRIPTION
The type-323 vehicle-start hint derived the power-on timestamp from the message's message_time when createTime was absent. message_time is a naive server-local string, and the SAIC EU backend stamps it in CET/CEST (UTC+1/+2) — but the code attached UTC to it, pushing the pre-set Last Powered On Time up to 2 hours into the FUTURE (seen in a user's log: hint 'started at 11:45:18+00:00' while it was ~09:46 UTC).

- Prefer createTime (Unix epoch ms, timezone-unambiguous) only when it's plausible (recent, not future); otherwise anchor the hint to now(UTC). The message is processed within ~60s of the car starting, so 'now' is a reliable, timezone-safe stand-in — and never in the future.
- Drop the message_time fallback entirely (it can't be reliably localised).
- Belt-and-braces: hint_vehicle_started() now clamps any future start time to now, so a bad timestamp can't poison the power-on time or the interval maths regardless of caller.

Bumps to 1.2.0-beta10.