### PR TITLE
Expose status SOC for India BEVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Follow the normal configuration steps above and select **India** as your region.
 ### What works for India (confirmed on a real vehicle)
  
 - Vehicle status: doors, windows, boot, bonnet, lock state, climate state, interior/exterior temperature, range, odometer, tyre pressures, 12V battery voltage
+- State of Charge for BEVs, reported by the ordinary vehicle-status payload
 - Door lock / unlock (with automatic verification — MG India sometimes applies a command without confirming it, and the integration re-checks the vehicle state)
 - Climate control on / off
 - Windows open / close
@@ -94,7 +95,7 @@ Follow the normal configuration steps above and select **India** as your region.
  
 ### Not available for India
  
-- **All charging features** — state of charge, charging status/control, scheduled charging, battery heating, target SOC, and charging current entities are not created for India vehicles. MG India's platform does not expose charging data (it is not present in the iSmart India app either). If this changes, or a charging-capable India model is confirmed, support can be added — see the tracking issue.
+- **Charging data and control** — charging status/control, scheduled charging, battery heating, target SOC, charging current, and total battery capacity entities are not created for India vehicles. The BEV State of Charge above comes from vehicle status; MG India's platform still does not expose the separate charging endpoint (it is not present in the iSmart India app either).
 - Window **ventilate** (crack open) — not yet confirmed safe on the India protocol; the open/close buttons work.
 - Event-driven updates — India vehicles use regular polling only.
  

--- a/custom_components/mg_saic/backends/__init__.py
+++ b/custom_components/mg_saic/backends/__init__.py
@@ -54,6 +54,7 @@ class Feature(str, Enum):
 
     # Data retrieval
     STATUS = "status"                            # get_vehicle_status
+    STATE_OF_CHARGE = "state_of_charge"          # SOC from status or charging data
     CHARGING_DATA = "charging_data"              # get_charging_info (incl. SOC)
     ALARM_MESSAGES = "alarm_messages"            # get_alarm_messages / set_alarm_switches / message poller
 
@@ -85,15 +86,15 @@ class Feature(str, Enum):
 GLOBAL_FEATURES: frozenset[Feature] = frozenset(Feature)
 
 # Features implemented AND confirmed on a real vehicle by the India TAP
-# client (John Lazarus, mg-ismart-india-ha).  Charging is deliberately
-# absent: MG India's platform does not offer charging data or control (it is
-# not present in the Comet EV's app), so every charging/SOC/scheduled-
-# charging/battery-heating entity is hidden for India accounts.
+# client (John Lazarus, mg-ismart-india-ha). MG India reports BEV state of
+# charge in the ordinary vehicle-status payload, but separate charging data
+# and charging controls are deliberately absent.
 # ALARM_MESSAGES is absent because the TAP protocol has no message-list
 # endpoint — the account message poller must not run for India accounts.
 INDIA_FEATURES: frozenset[Feature] = frozenset(
     {
         Feature.STATUS,
+        Feature.STATE_OF_CHARGE,
         Feature.LOCK,
         Feature.TAILGATE,
         Feature.WINDOWS,

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -209,6 +209,7 @@ class IndiaBackend:
             interiorTemperature=getattr(status, "interior_temperature", None),
             exteriorTemperature=getattr(status, "exterior_temperature", None),
             fuelLevelPrc=getattr(status, "fuel_level", None),
+            extendedData1=getattr(status, "fuel_level", None),
             fuelRange=range_tenths,
             fuelRangeElec=range_tenths,
             mileage=_tenths(getattr(status, "odometer_km", None)),

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -312,20 +312,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 ),
             )
 
-            # SOC and battery capacity are sourced from the charging endpoint.
-            # The coordinator only fetches that endpoint for BEV/PHEV — never
-            # for HEV, because a full (non-plug-in) hybrid has no externally
-            # reported traction-battery charging data (see the fetch gate in
-            # coordinator.py: vehicle_type in ["BEV", "PHEV"]). Creating these
-            # two sensors for an HEV therefore produced permanently-unavailable
-            # entities that also logged "No charging data available for ..." as
-            # an ERROR on *every* poll (issue #258 — MG3 Hybrid, series ZP22).
-            # Mirror the coordinator's own gate here so sensor creation matches
-            # data availability. The backend_supports() check is retained so the
-            # India two-backend path (which reports no charging data at all —
-            # issue #169) stays correct.
-            if vehicle_type in ["BEV", "PHEV"] and coordinator.backend_supports(
-                Feature.CHARGING_DATA
+            # SOC may come from ordinary status or the charging endpoint.
+            if (
+                vehicle_type in ["BEV", "PHEV"]
+                and coordinator.backend_supports(Feature.STATE_OF_CHARGE)
+                and (
+                    vehicle_type == "BEV"
+                    or coordinator.backend_supports(Feature.CHARGING_DATA)
+                )
             ):
                 sensors.append(
                     SAICMGSOCSensor(
@@ -343,6 +337,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     )
                 )
 
+            # Battery capacity is only available from the separate charging
+            # endpoint. HEVs do not expose that endpoint, and India does not
+            # advertise it even though India BEVs report SOC in status.
+            if vehicle_type in ["BEV", "PHEV"] and coordinator.backend_supports(
+                Feature.CHARGING_DATA
+            ):
                 sensors.append(
                     SAICMGChargingSensor(
                         coordinator,
@@ -1665,8 +1665,7 @@ class SAICMGSOCSensor(CoordinatorEntity, SensorEntity):
         self._device_info = create_device_info(coordinator, entry.entry_id)
 
         # Retain last valid SOC so the sensor does not drop to Unknown when the
-        # API is temporarily unavailable. SOC of 0 from the basic status field
-        # is treated as invalid and ignored (same as -1 sentinel).
+        # API is temporarily unavailable.
         self._last_valid_soc: float | None = None
 
     @property
@@ -1683,8 +1682,7 @@ class SAICMGSOCSensor(CoordinatorEntity, SensorEntity):
         """Return True if the entity is available."""
         if self._last_valid_soc is not None:
             return True
-        required_data = self.coordinator.data.get(self._data_type)
-        return self.coordinator.last_update_success and required_data is not None
+        return self.coordinator.last_update_success and self.native_value is not None
 
     @property
     def native_value(self):
@@ -1710,7 +1708,7 @@ class SAICMGSOCSensor(CoordinatorEntity, SensorEntity):
                 status_data = getattr(status, self._status_type, None)
                 if status_data:
                     soc = getattr(status_data, self._field_basic, None)
-                    if soc in (-128, -1, 0):
+                    if soc in (-128, -1):
                         soc = None
 
         if soc is not None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -17,8 +17,8 @@
 #   * Backend selection: region "India" -> IndiaBackend, everything else ->
 #     the untouched global SAICMGAPIClient.
 #   * Capability sets: charging/alarm families must stay OUT of
-#     INDIA_FEATURES until confirmed on a real car; confirmed features must
-#     stay IN.
+#     INDIA_FEATURES until confirmed on a real car; status-reported SOC and
+#     other confirmed features must stay IN.
 #   * Legacy fallback: clients that declare no feature set are treated as
 #     fully featured (pre-split global behaviour).
 
@@ -191,6 +191,7 @@ class TestCapabilitySets(unittest.TestCase):
     # Confirmed on-car by John Lazarus for MG India (Discussion #169).
     INDIA_CONFIRMED = {
         Feature.STATUS,
+        Feature.STATE_OF_CHARGE,
         Feature.LOCK,
         Feature.TAILGATE,
         Feature.WINDOWS,

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -1,0 +1,360 @@
+"""Regression coverage for MG India BEV state of charge."""
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+PACKAGE = "mg_saic_india_soc_test"
+LOADED_MODULE_NAMES = (
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.sensor",
+    "homeassistant.helpers",
+    "homeassistant.helpers.entity",
+    "homeassistant.helpers.update_coordinator",
+    "homeassistant.const",
+    "aiohttp",
+    "mg_ismart_india_client",
+    PACKAGE,
+    f"{PACKAGE}.const",
+    f"{PACKAGE}.utils",
+    f"{PACKAGE}.api",
+    f"{PACKAGE}.backends",
+    f"{PACKAGE}.backends.india",
+    f"{PACKAGE}.sensor",
+)
+
+
+class _Values:
+    def __getattr__(self, name):
+        return name.lower()
+
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+def _module(name, **attributes):
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load(name, path, *, package=False):
+    kwargs = {"submodule_search_locations": [str(path.parent)]} if package else {}
+    spec = importlib.util.spec_from_file_location(name, path, **kwargs)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_modules():
+    previous_modules = {
+        name: sys.modules[name] for name in LOADED_MODULE_NAMES if name in sys.modules
+    }
+    try:
+        homeassistant = _module("homeassistant")
+        homeassistant.__path__ = []
+        components = _module("homeassistant.components")
+        components.__path__ = []
+        helpers = _module("homeassistant.helpers")
+        helpers.__path__ = []
+
+        class _SensorEntity:
+            pass
+
+        _module(
+            "homeassistant.components.sensor",
+            SensorEntity=_SensorEntity,
+            SensorDeviceClass=_Values(),
+        )
+        _module("homeassistant.helpers.entity", EntityCategory=_Values())
+        _module(
+            "homeassistant.helpers.update_coordinator",
+            CoordinatorEntity=_CoordinatorEntity,
+        )
+        _module(
+            "homeassistant.const",
+            PERCENTAGE="%",
+            UnitOfTemperature=_Values(),
+            UnitOfElectricPotential=_Values(),
+            UnitOfLength=_Values(),
+            UnitOfPressure=_Values(),
+            UnitOfEnergy=_Values(),
+            UnitOfTime=_Values(),
+            UnitOfPower=_Values(),
+            UnitOfSpeed=_Values(),
+        )
+
+        package = _module(PACKAGE)
+        package.__path__ = [str(PKG_DIR)]
+        _module(
+            f"{PACKAGE}.const",
+            DOMAIN="mg_saic",
+            LOGGER=logging.getLogger(PACKAGE),
+            VEHICLE_REACHABILITY_AWAKE="awake",
+            VEHICLE_REACHABILITY_LIKELY_ASLEEP="likely_asleep",
+            VEHICLE_REACHABILITY_UNREACHABLE="unreachable",
+            DATA_FRESHNESS_LIVE="live",
+            DATA_FRESHNESS_CACHED="cached",
+            DATA_FRESHNESS_FAILED="failed",
+            PRESSURE_TO_BAR=0.1,
+            DATA_DECIMAL_CORRECTION=0.1,
+            DATA_DECIMAL_CORRECTION_SOC=0.1,
+            CHARGING_CURRENT_FACTOR=0.05,
+            CHARGING_VOLTAGE_FACTOR=0.25,
+            DATA_100_DECIMAL_CORRECTION=0.01,
+        )
+        _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})
+
+        class _GlobalClient:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+        _module(f"{PACKAGE}.api", SAICMGAPIClient=_GlobalClient)
+
+        aiohttp = _module("aiohttp")
+        aiohttp.ClientSession = object
+
+        class _IndiaApiError(Exception):
+            pass
+
+        _module(
+            "mg_ismart_india_client",
+            MgIndiaApiError=_IndiaApiError,
+            MgIndiaClient=object,
+            hash_control_pin=lambda pin: pin,
+        )
+
+        backends = _load(
+            f"{PACKAGE}.backends",
+            PKG_DIR / "backends" / "__init__.py",
+            package=True,
+        )
+        india = _load(
+            f"{PACKAGE}.backends.india",
+            PKG_DIR / "backends" / "india.py",
+        )
+        sensor = _load(f"{PACKAGE}.sensor", PKG_DIR / "sensor.py")
+        return backends, india, sensor
+    finally:
+        for name in LOADED_MODULE_NAMES:
+            if name in previous_modules:
+                sys.modules[name] = previous_modules[name]
+            else:
+                sys.modules.pop(name, None)
+
+
+BACKENDS, INDIA, SENSOR = _load_modules()
+
+
+class IndiaBEVStateOfChargeTests(unittest.TestCase):
+    def _setup_entities(self, backend, vehicle_type, status, charging=None):
+        vin_info = SimpleNamespace(
+            vin="VIN1",
+            brandName="MG",
+            modelName="Test Vehicle",
+            modelYear="2026",
+        )
+        coordinator = SimpleNamespace(
+            data={"info": [vin_info], "status": status, "charging": charging},
+            vin_info=vin_info,
+            vehicle_type=vehicle_type,
+            client=backend,
+            last_update_success=True,
+            has_heated_seats=False,
+            has_battery_heating=False,
+            has_steering_wheel_heat=False,
+            supports_charging_current_limit=False,
+            supports_target_soc=False,
+        )
+        coordinator.backend_supports = lambda feature: BACKENDS.backend_supports(
+            backend, feature
+        )
+        entry = SimpleNamespace(entry_id="entry-1")
+        hass = SimpleNamespace(
+            data={"mg_saic": {"entry-1_coordinator": coordinator}}
+        )
+        entities = []
+
+        asyncio.run(
+            SENSOR.async_setup_entry(
+                hass,
+                entry,
+                lambda added, update_before_add: entities.extend(added),
+            )
+        )
+        return entities
+
+    @staticmethod
+    def _india_status(backend, percentage):
+        return backend._map_status(
+            SimpleNamespace(
+                status_time=1_800_000_000,
+                fuel_level=percentage,
+                raw={"basicVehicleStatus": {}},
+            )
+        )
+
+    def test_status_soc_creates_only_soc_battery_entity(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        entities = self._setup_entities(
+            backend,
+            "BEV",
+            self._india_status(backend, 62),
+        )
+
+        soc_entities = [
+            entity for entity in entities if isinstance(entity, SENSOR.SAICMGSOCSensor)
+        ]
+        self.assertEqual(len(soc_entities), 1)
+        self.assertEqual(soc_entities[0].native_value, 62)
+        self.assertTrue(soc_entities[0].available)
+        self.assertFalse(
+            any(
+                isinstance(entity, SENSOR.SAICMGChargingSensor)
+                and entity._name == "Total Battery Capacity"
+                for entity in entities
+            )
+        )
+
+    def test_status_soc_accepts_initial_zero(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        entities = self._setup_entities(
+            backend,
+            "BEV",
+            self._india_status(backend, 0),
+        )
+        soc = next(
+            entity for entity in entities if isinstance(entity, SENSOR.SAICMGSOCSensor)
+        )
+
+        self.assertTrue(soc.available)
+        self.assertEqual(soc.native_value, 0)
+
+    def test_status_soc_updates_from_62_to_zero(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        entities = self._setup_entities(
+            backend,
+            "BEV",
+            self._india_status(backend, 62),
+        )
+        soc = next(
+            entity for entity in entities if isinstance(entity, SENSOR.SAICMGSOCSensor)
+        )
+        self.assertEqual(soc.native_value, 62)
+
+        soc.coordinator.data["status"] = self._india_status(backend, 0)
+
+        self.assertEqual(soc.native_value, 0)
+
+    def test_status_soc_is_unavailable_without_a_valid_initial_value(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        statuses = {
+            "missing": SimpleNamespace(basicVehicleStatus=SimpleNamespace()),
+            "none": self._india_status(backend, None),
+            "minus_one": self._india_status(backend, -1),
+            "minus_128": self._india_status(backend, -128),
+        }
+
+        for case, status in statuses.items():
+            with self.subTest(case=case):
+                entities = self._setup_entities(backend, "BEV", status)
+                soc = next(
+                    entity
+                    for entity in entities
+                    if isinstance(entity, SENSOR.SAICMGSOCSensor)
+                )
+
+                self.assertFalse(soc.available)
+                self.assertIsNone(soc.native_value)
+
+    def test_status_soc_retains_last_valid_value_during_temporary_failure(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        entities = self._setup_entities(
+            backend,
+            "BEV",
+            self._india_status(backend, 62),
+        )
+        soc = next(
+            entity for entity in entities if isinstance(entity, SENSOR.SAICMGSOCSensor)
+        )
+        self.assertEqual(soc.native_value, 62)
+
+        soc.coordinator.data["status"] = self._india_status(backend, -1)
+        soc.coordinator.last_update_success = False
+
+        self.assertEqual(soc.native_value, 62)
+        self.assertTrue(soc.available)
+
+    def test_module_loader_restores_imports(self):
+        missing = object()
+        before = {
+            name: sys.modules.get(name, missing) for name in LOADED_MODULE_NAMES
+        }
+
+        _load_modules()
+
+        for name in LOADED_MODULE_NAMES:
+            with self.subTest(module=name):
+                self.assertIs(sys.modules.get(name, missing), before[name])
+
+    def test_global_phev_keeps_charging_soc_and_battery_capacity(self):
+        backend = SimpleNamespace(supported_features=BACKENDS.GLOBAL_FEATURES)
+        status = SimpleNamespace(
+            basicVehicleStatus=SimpleNamespace(extendedData1=61)
+        )
+        charging = SimpleNamespace(
+            chrgMgmtData=SimpleNamespace(bmsPackSOCDsp=620),
+            rvsChargeStatus=SimpleNamespace(totalBatteryCapacity=300),
+        )
+
+        entities = self._setup_entities(backend, "PHEV", status, charging)
+        soc = next(
+            entity for entity in entities if isinstance(entity, SENSOR.SAICMGSOCSensor)
+        )
+
+        self.assertEqual(soc.native_value, 62)
+        self.assertTrue(
+            any(
+                isinstance(entity, SENSOR.SAICMGChargingSensor)
+                and entity._name == "Total Battery Capacity"
+                for entity in entities
+            )
+        )
+
+    def test_india_non_bevs_keep_fuel_level_without_soc(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        status = self._india_status(backend, 47)
+
+        for vehicle_type in ("PHEV", "HEV", "ICE"):
+            with self.subTest(vehicle_type=vehicle_type):
+                entities = self._setup_entities(backend, vehicle_type, status)
+                fuel_level = next(
+                    entity
+                    for entity in entities
+                    if isinstance(entity, SENSOR.SAICMGVehicleSensor)
+                    and entity._name == "Fuel Level"
+                )
+                self.assertEqual(fuel_level.native_value, 47)
+                self.assertFalse(
+                    any(
+                        isinstance(entity, SENSOR.SAICMGSOCSensor)
+                        for entity in entities
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a `STATE_OF_CHARGE` backend capability, separate from `CHARGING_DATA`
- map India BEV `fuelLevelPrc` from ordinary vehicle status to the existing State of Charge entity
- keep battery capacity and every charging-related entity/control behind `CHARGING_DATA`
- preserve global BEV/PHEV SOC and India ICE/HEV/PHEV fuel-level behaviour

## Validation

- live MG Comet status: `fuelLevelPrc = 100%`
- exact HACS candidate: State of Charge appeared at `100%`
- no India charging, battery-capacity, target-SOC, schedule or battery-heating entities appeared
- initial `0%`, `62% → 0%`, missing/invalid status, retained-value, propulsion gating and import-isolation regressions covered
- full suite: **91 passed, 23 subtests passed**
- fork CI: Python tests, hassfest and HACS validation passed

This is ordinary status-reported battery percentage, not India charging support.

Related discussion: https://github.com/townsmcp/mg-saic-ha/discussions/220
