### PR TITLE
fix(climate): A/C switch + Climate Mode select go unavailable when unreachable

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.1"
+  "version": "1.2.2-beta1"
 }

--- a/custom_components/mg_saic/select.py
+++ b/custom_components/mg_saic/select.py
@@ -456,6 +456,16 @@ class SAICMGClimateModeSelect(CoordinatorEntity, SelectEntity):
         return self._device_info
 
     @property
+    def available(self):
+        """Unavailable whenever the climate entity is (e.g. the car is
+        unreachable), so the mode select mirrors the climate entity it
+        controls rather than showing a stale selection."""
+        climate = self.coordinator.climate_entity
+        if climate is None:
+            return False
+        return climate.available
+
+    @property
     def current_option(self):
         """Reflect the climate entity's reconciled mode, so the select never
         disagrees with it (unlike decoding the raw status separately, which

--- a/custom_components/mg_saic/switch.py
+++ b/custom_components/mg_saic/switch.py
@@ -973,6 +973,16 @@ class SAICMGACSwitch(CoordinatorEntity, SwitchEntity):
         return self._device_info
 
     @property
+    def available(self):
+        """Unavailable whenever the climate entity is (e.g. the car is
+        unreachable), so the switch doesn't show a definite Off when we can't
+        actually tell — it mirrors the climate entity it controls."""
+        climate = self.coordinator.climate_entity
+        if climate is None:
+            return False
+        return climate.available
+
+    @property
     def is_on(self):
         """Whether the A/C is on.
 


### PR DESCRIPTION
The climate entity's 'available' requires status data, so it correctly reads 'unavailable' when the car is unreachable. The A/C switch and Climate Mode select used the default coordinator availability (last_update_success, still true on cached data), so they showed a definite 'off' / stale option during an outage. Both now mirror the climate entity's availability, so all three climate controls report unavailable together rather than a misleading state.

No version bump (beta sitting at 1.2.1 pending release decision).