### PR TITLE
feat: MGS5 EV climate profile + transient temperature-spike guard (#277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ The MG SAIC integration exposes a climate entity for remote control of the vehic
  
 Not all MG models expose climate control the same way, so the integration uses one of two schemes depending on your vehicle:
  
-- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes (and `Heat` on models with a confirmed heater, e.g. the MG4 Electric). This is the default and covers the standard MG4, MGS5, Cyberster, HS PHEV, and any model not specifically profiled.
-- **Mode-select models (e.g. MG S9 PHEV, MG4 EV URBAN):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle. Available modes and presets vary by model — a car is only offered `Heat` or a `Defrost` preset if it actually supports them (the MG4 EV URBAN, for example, has no heat mode).
+- **Fan-speed models (most cars):** a Low / Medium / High fan slider plus `Cool` / `Fan Only` / `Off` HVAC modes (and `Heat` on models with a confirmed heater, e.g. the MG4 Electric). This is the default and covers the standard MG4, Cyberster, HS PHEV, and any model not specifically profiled.
+- **Mode-select models (e.g. MGS5 EV, MGS6 EV, MG S9 PHEV, MG4 EV URBAN):** on some cars the SAIC API's "fan speed" value is not a fan speed at all — it is a fixed climate *mode* selector, and the car chooses its own fan speed. On these models a Low/Med/High slider is misleading, so instead the integration exposes HVAC modes and presets that map to the car's actual modes (see below). The correct scheme is selected automatically based on your vehicle. Available modes and presets vary by model — a car is only offered `Heat` or a `Defrost` preset if it actually supports them (the MG4 EV URBAN, for example, has no heat mode).
 - **Simple-AC models (e.g. MG3 Hybrid):** a few cars only act on the basic AC command and ignore everything else, so they get a stripped-back `Cool` / `Heat` / `Off` climate entity (Cool = coldest, Heat = warmest) with no fan slider (see below).
  
 ### How commands are used
@@ -577,6 +577,7 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
 | `EH32` | MG4 Electric | Temperature range and fan speed values confirmed; PTC resistive **Heat** mode supported (#173) |
 | `AH4EM` | MG4 EV URBAN | Mode-select climate scheme (owner-confirmed, #243); this variant has no heat mode — see [Climate Control](#climate-control) |
 | `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index; model year override (API reports 2024, corrected to 2025) |
+| `MZS3E` | MGS5 EV | Mode-select climate scheme mirroring the MGS6 (status code 2 = cool, #277); battery capacity and temperature index inherited from the MGS6 as best-effort and not independently confirmed |
 | `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |
 | `IS31P` | MG S9 PHEV (2025) | Climate status/fan speed mappings confirmed by physical testing |
 | `AS33P` | MG HS PHEV (Super Hybrid 2025/2026) | Battery capacity 24.7 kWh; Target SOC and Charging Current Limit not supported by iSmart; electric range uses live SOC-tracking field; energy values corrected for ~3x API over-reporting |

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -354,6 +354,40 @@ VEHICLE_PROFILES = {
         "climate_status_heat": {4},
         "climate_status_defrost": {5},
     },
+    "MZS3E": {  # MGS5 EV (sister to the MGS6 / MIS3E) — see #277
+        # Confirmed by owner @jeffreyguilmot (#277, series 'MZS3E S'): the MGS5
+        # cools at remoteClimateStatus=2 (iSmart app shows AC on, cabin cools
+        # rapidly) — but with no dedicated profile it fell through to
+        # DEFAULT_VEHICLE_PROFILE, which maps 2 -> fan_only, so the climate
+        # entity misreported "fan_only" while the car was actually cooling.
+        # The MGS5 shares the MGS6's mode_select climate scheme, so the climate
+        # config mirrors MIS3E. NOTE: battery_capacity_kwh and temp_index_map
+        # are inherited from the MGS6 as best-effort and are NOT independently
+        # confirmed for the MGS5 (variants differ) — the confirmed change here
+        # is the climate_status mapping.
+        "min_temp": 16,
+        "max_temp": 30,
+        "temp_offset": 2,
+        "battery_capacity_kwh": None,  # MGS5 variants differ; unconfirmed
+        "temp_idx_inverted": False,
+        "temp_index_map": {
+            16: 1, 17: 3, 18: 4, 19: 5, 20: 6, 21: 7, 22: 8, 23: 9, 24: 10,
+            25: 11, 26: 12, 27: 13, 28: 14, 29: 16, 30: 19,
+        },
+        "supports_target_soc": True,
+        "reliable_fuel_range_elec": True,
+        # --- mode_select climate scheme (mirrors the MGS6) ---
+        "climate_control_scheme": "mode_select",
+        "climate_mode_cool": 2,
+        "climate_mode_defrost": 5,
+        "climate_mode_fan_only": 1,
+        "climate_mode_heat": 4,
+        "climate_mode_max_cool": 3,
+        "climate_status_cool": {2, 3},   # CONFIRMED 2=cool on the MGS5 (#277)
+        "climate_status_fan_only": {1},
+        "climate_status_heat": {4},
+        "climate_status_defrost": {5},
+    },
     "EC32": {  # MG Cyberster (2-door BEV roadster/convertible)
         # The Cyberster has no rear doors or rear windows — see the
         # has_rear_doors/has_rear_windows override at the bottom of this
@@ -807,6 +841,19 @@ STARTUP_CHARGING_TIMEOUT = 12
 # (reported by @HarryFlatter, #262). Charging is non-essential (status is the
 # core payload), so we bound it and proceed without it on failure.
 RUNTIME_CHARGING_TIMEOUT = 20
+
+# Transient temperature-spike guard (#277). Some status refreshes — especially
+# a wake-from-idle or the refresh right after a climate command — briefly report
+# bad temperature values across fields (e.g. exterior 33°C -> 45°C, interior
+# jumping the wrong way while cooling). If a reading jumps more than
+# TEMP_SPIKE_MAX_JUMP_C from the last accepted value AND the last accepted value
+# was within TEMP_SPIKE_GUARD_WINDOW_S seconds (i.e. rapid polling, not a normal
+# long idle gap), we skip that SINGLE reading and retain the last value. The
+# next reading is always accepted, so a genuinely fast change is only delayed
+# one poll and never permanently hidden. Deliberately generous: air temperature
+# can't plausibly move this much this fast, even with the A/C running flat out.
+TEMP_SPIKE_MAX_JUMP_C = 10
+TEMP_SPIKE_GUARD_WINDOW_S = 300
 
 # Charging status codes indicating that the vehicle is actively using the
 # charging/discharging system.  Used by the coordinator to select the

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "saic-ismart-client-ng==0.9.3",
     "mg-ismart-india-client==0.1.1"
   ],
-  "version": "1.2.2-beta1"
+  "version": "1.2.2-beta2"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -15,9 +15,13 @@ from homeassistant.const import (
     UnitOfSpeed,
 )
 from .backends import Feature
+from datetime import datetime, timezone
+
 from .const import (
     DOMAIN,
     LOGGER,
+    TEMP_SPIKE_MAX_JUMP_C,
+    TEMP_SPIKE_GUARD_WINDOW_S,
     VEHICLE_REACHABILITY_AWAKE,
     VEHICLE_REACHABILITY_LIKELY_ASLEEP,
     VEHICLE_REACHABILITY_UNREACHABLE,
@@ -817,6 +821,8 @@ class SAICMGVehicleSensor(CoordinatorEntity, SensorEntity):
         # Per-field retention for temperature fields (keyed by field name so a
         # single class instance cannot cross-contaminate different sensors).
         self._last_valid_temperature: dict[str, float] = {}
+        self._last_valid_temperature_ts: dict[str, datetime] = {}
+        self._temp_spike_skipped: dict[str, bool] = {}
 
         # Generic last-known-good value for all other retainable numeric fields.
         # Mapped/string fields use _last_valid_mapped instead.
@@ -902,7 +908,35 @@ class SAICMGVehicleSensor(CoordinatorEntity, SensorEntity):
                                 )
                                 return self._last_valid_temperature.get(self._field)
                             computed = raw_value * self._factor
+                            # Transient-spike guard (#277): skip a SINGLE reading
+                            # that jumps implausibly fast, retaining the last
+                            # value. The next reading is always accepted, so a
+                            # genuine rapid change is only delayed one poll and
+                            # never permanently hidden.
+                            last = self._last_valid_temperature.get(self._field)
+                            last_ts = self._last_valid_temperature_ts.get(self._field)
+                            now = datetime.now(timezone.utc)
+                            if (
+                                last is not None
+                                and last_ts is not None
+                                and not self._temp_spike_skipped.get(self._field)
+                                and (now - last_ts).total_seconds()
+                                <= TEMP_SPIKE_GUARD_WINDOW_S
+                                and abs(computed - last) > TEMP_SPIKE_MAX_JUMP_C
+                            ):
+                                LOGGER.debug(
+                                    "Sensor %s: implausible temperature jump "
+                                    "%.1f°C→%.1f°C in %.0fs — skipping one reading",
+                                    self._name,
+                                    last,
+                                    computed,
+                                    (now - last_ts).total_seconds(),
+                                )
+                                self._temp_spike_skipped[self._field] = True
+                                return last
+                            self._temp_spike_skipped[self._field] = False
                             self._last_valid_temperature[self._field] = computed
+                            self._last_valid_temperature_ts[self._field] = now
                             return computed
 
                         # --- Mapped / enum fields ---

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -115,6 +115,8 @@ def _load_modules():
             CHARGING_CURRENT_FACTOR=0.05,
             CHARGING_VOLTAGE_FACTOR=0.25,
             DATA_100_DECIMAL_CORRECTION=0.01,
+            TEMP_SPIKE_MAX_JUMP_C=10,
+            TEMP_SPIKE_GUARD_WINDOW_S=300,
         )
         _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})
 


### PR DESCRIPTION
Two fixes from @jeffreyguilmot's MGS5 EV report:

1. MGS5 EV (series MZS3E) had no profile, so it fell to DEFAULT_VEHICLE_PROFILE which maps remoteClimateStatus=2 -> fan_only. But the MGS5 cools at status 2 (app confirms AC on + rapid cabin cooling), like its MGS6 sibling. Added an MZS3E profile mirroring the MGS6's mode_select scheme with climate_status_cool={2,3}, so 'Cool' now reports correctly. (Battery capacity and temp index map are inherited from the MGS6 as best-effort, unconfirmed.)

2. Some status refreshes (esp. wake-from-idle / just after a climate command) briefly report bad temperatures across fields (e.g. exterior 33->45C, interior jumping the wrong way while cooling). Added a skip-one transient guard: a reading that jumps more than TEMP_SPIKE_MAX_JUMP_C (10C) from the last accepted value within TEMP_SPIKE_GUARD_WINDOW_S (300s) is skipped once and the last value retained; the next reading is always accepted, so a genuine rapid change is only delayed one poll, never permanently hidden. Long idle gaps are never guarded.

Bumps to 1.2.2-beta2.