### PR TITLE
fix(sensor): mileage no longer sticks at 6553.5 km (uint16 overflow)  (#280)

### DIFF
--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -855,6 +855,12 @@ RUNTIME_CHARGING_TIMEOUT = 20
 TEMP_SPIKE_MAX_JUMP_C = 10
 TEMP_SPIKE_GUARD_WINDOW_S = 300
 
+# basicVehicleStatus.mileage is a 16-bit field, so once the odometer passes
+# 6553.5 km it saturates at the uint16 maximum (65535) and stays there (#280).
+# Treat that exact value as invalid so the mileage sensor falls back to the
+# wider ChrgMgmtData.mileage field, which holds the true odometer.
+MILEAGE_UINT16_SATURATION = 65535
+
 # Charging status codes indicating that the vehicle is actively using the
 # charging/discharging system.  Used by the coordinator to select the
 # charging update interval and keep the session alive.

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -22,6 +22,7 @@ from .const import (
     LOGGER,
     TEMP_SPIKE_MAX_JUMP_C,
     TEMP_SPIKE_GUARD_WINDOW_S,
+    MILEAGE_UINT16_SATURATION,
     VEHICLE_REACHABILITY_AWAKE,
     VEHICLE_REACHABILITY_LIKELY_ASLEEP,
     VEHICLE_REACHABILITY_UNREACHABLE,
@@ -729,7 +730,21 @@ class SAICMGMileageSensor(CoordinatorEntity, SensorEntity):
                 # Reject zero, None, and any negative value (includes -128 sentinel).
                 # Mileage is always a positive, monotonically increasing odometer
                 # reading — any value <= 0 is invalid API data.
-                if mileage is None or mileage <= 0:
+                # Also reject the uint16 saturation value (65535): basicVehicleStatus
+                # mileage is a 16-bit field that sticks at 65535 once the odometer
+                # passes 6553.5 km (#280). Rejecting it here falls through to the
+                # wider ChrgMgmtData.mileage field below, which holds the real value.
+                if (
+                    mileage is None
+                    or mileage <= 0
+                    or mileage == MILEAGE_UINT16_SATURATION
+                ):
+                    if mileage == MILEAGE_UINT16_SATURATION:
+                        LOGGER.debug(
+                            "Mileage from status is saturated (%s); falling back "
+                            "to charging-data odometer",
+                            MILEAGE_UINT16_SATURATION,
+                        )
                     mileage = None
                 else:
                     mileage = mileage * self._factor

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -117,6 +117,7 @@ def _load_modules():
             DATA_100_DECIMAL_CORRECTION=0.01,
             TEMP_SPIKE_MAX_JUMP_C=10,
             TEMP_SPIKE_GUARD_WINDOW_S=300,
+            MILEAGE_UINT16_SATURATION=65535,
         )
         _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})
 


### PR DESCRIPTION
basicVehicleStatus.mileage is a 16-bit field that saturates at the uint16 maximum (65535) once the odometer passes 6553.5 km, and then stays there. The mileage sensor accepted 65535 as a valid positive reading (65535 * 0.1 = 6553.5), so it never fell through to the wider ChrgMgmtData.mileage field, which holds the true odometer (e.g. 68250 = 6825.0 km on the reporter's MG4).

Reject the exact 65535 saturation value from the status source so the sensor falls back to the charging-data odometer. The monotonic-retain guard then corrects a previously-stuck value on the next poll. Charging-data mileage is a wider field and is left unchanged (65535 there would be a legitimate reading). BEV/PHEV get the correct value from charging data; for HEV/ICE without charging data over 6553.5 km there's no alternative source, so the sensor honestly shows unavailable rather than a wrong stuck value.

Also extended test_india_soc.py's stub const with the new constant.

No version bump (beta manifest reads 1.2.2-beta1 already carrying beta2 content — bump to taste on merge).