### PR TITLE
feat(mgs5): set confirmed 64 kWh battery capacity (#277/#278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
 | `EH32` | MG4 Electric | Temperature range and fan speed values confirmed; PTC resistive **Heat** mode supported (#173) |
 | `AH4EM` | MG4 EV URBAN | Mode-select climate scheme (owner-confirmed, #243); this variant has no heat mode — see [Climate Control](#climate-control) |
 | `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index; model year override (API reports 2024, corrected to 2025) |
-| `MZS3E` | MGS5 EV | Mode-select climate scheme mirroring the MGS6 (status code 2 = cool, #277); battery capacity and temperature index inherited from the MGS6 as best-effort and not independently confirmed |
+| `MZS3E` | MGS5 EV | Mode-select climate scheme mirroring the MGS6 (status code 2 = cool, #277); battery capacity confirmed 64 kWh (EU169A64S); temperature index inherited from the MGS6 as best-effort |
 | `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |
 | `IS31P` | MG S9 PHEV (2025) | Climate status/fan speed mappings confirmed by physical testing |
 | `AS33P` | MG HS PHEV (Super Hybrid 2025/2026) | Battery capacity 24.7 kWh; Target SOC and Charging Current Limit not supported by iSmart; electric range uses live SOC-tracking field; energy values corrected for ~3x API over-reporting |

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -361,14 +361,17 @@ VEHICLE_PROFILES = {
         # DEFAULT_VEHICLE_PROFILE, which maps 2 -> fan_only, so the climate
         # entity misreported "fan_only" while the car was actually cooling.
         # The MGS5 shares the MGS6's mode_select climate scheme, so the climate
-        # config mirrors MIS3E. NOTE: battery_capacity_kwh and temp_index_map
-        # are inherited from the MGS6 as best-effort and are NOT independently
-        # confirmed for the MGS5 (variants differ) — the confirmed change here
-        # is the climate_status mapping.
+        # config mirrors MIS3E. Battery capacity is CONFIRMED by the owner
+        # (@jeffreyguilmot, #277/#278): MGS5 EV 64 kWh RWD, battery type
+        # EU169A64S. temp_index_map is still inherited from the MGS6 as
+        # best-effort and NOT independently confirmed for the MGS5.
         "min_temp": 16,
         "max_temp": 30,
         "temp_offset": 2,
-        "battery_capacity_kwh": None,  # MGS5 variants differ; unconfirmed
+        # 64 kWh pack (EU169A64S) — nominal/pack capacity per the owner's manual.
+        # Note the convention above is "usable"; owner requested the 64 kWh pack
+        # figure and it matches the "Total Battery Capacity" sensor name.
+        "battery_capacity_kwh": 64.0,
         "temp_idx_inverted": False,
         "temp_index_map": {
             16: 1, 17: 3, 18: 4, 19: 5, 20: 6, 21: 7, 22: 8, 23: 9, 24: 10,


### PR DESCRIPTION
The MGS5 profile left battery_capacity_kwh as None (best-effort), so sensor.total_battery_capacity read 'unknown'. Owner @jeffreyguilmot confirmed the exact spec: MGS5 EV 64 kWh RWD, battery type EU169A64S. Set battery_capacity_kwh = 64.0 so Total Battery Capacity populates.

Note: the profile convention comment says 'usable' capacity; 64 kWh is the nominal/pack figure the owner confirmed from the manual, and it matches the 'Total Battery Capacity' sensor name. README profile-table row updated.

No version bump (beta manifest reads 1.2.2-beta1; bump on merge).