### PR TITLE
Update MG India client to 0.1.2

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "saic-ismart-client-ng==0.9.3",
-    "mg-ismart-india-client==0.1.1"
+    "mg-ismart-india-client==0.1.2"
   ],
-  "version": "1.2.2-beta2"
+  "version": "1.2.2-beta3"
 }


### PR DESCRIPTION
Pins the India backend to `mg-ismart-india-client==0.1.2` and bumps the beta manifest to `1.2.2-beta3`.

0.1.2 caps login passwords to the app's 16-character limit and surfaces definitive login rejections without spending the remaining retry attempts.

`python3 -m venv .venv`, `.venv/bin/python -m pip install mg-ismart-india-client==0.1.2`, and `.venv/bin/python -m unittest discover -s tests -p 'test_*.py'` pass locally.
