### PR TITLE
fix(sensor): rate-based temperature spike guard (#277)

### DIFF
--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -847,16 +847,20 @@ RUNTIME_CHARGING_TIMEOUT = 20
 
 # Transient temperature-spike guard (#277). Some status refreshes — especially
 # a wake-from-idle or the refresh right after a climate command — briefly report
-# bad temperature values across fields (e.g. exterior 33°C -> 45°C, interior
-# jumping the wrong way while cooling). If a reading jumps more than
-# TEMP_SPIKE_MAX_JUMP_C from the last accepted value AND the last accepted value
-# was within TEMP_SPIKE_GUARD_WINDOW_S seconds (i.e. rapid polling, not a normal
-# long idle gap), we skip that SINGLE reading and retain the last value. The
-# next reading is always accepted, so a genuinely fast change is only delayed
-# one poll and never permanently hidden. Deliberately generous: air temperature
-# can't plausibly move this much this fast, even with the A/C running flat out.
-TEMP_SPIKE_MAX_JUMP_C = 10
-TEMP_SPIKE_GUARD_WINDOW_S = 300
+# bad temperature values (e.g. two readings 15 ms apart, 19°C then 13°C). We
+# reject a reading whose change from the last accepted value is physically
+# implausible *for the time elapsed*: allowed change = BASE_TOLERANCE +
+# MAX_RATE * seconds. This is rate-based rather than a fixed jump, so it also
+# catches a small delta over a tiny interval (a 6°C move in 15 ms is impossible
+# even though 6°C < any fixed threshold) — the original fixed-threshold guard
+# let those walk through in the same poll. Only ONE reading is ever skipped;
+# the next is always accepted, so a genuine change is delayed at most one poll
+# and never permanently hidden. Air temperature can't plausibly move faster
+# than a few °C/min even with the A/C flat out, so 0.1 °C/s (6 °C/min) is a
+# generous ceiling; BASE_TOLERANCE absorbs sensor noise on near-simultaneous
+# readings.
+TEMP_SPIKE_BASE_TOLERANCE_C = 3.0
+TEMP_SPIKE_MAX_RATE_C_PER_S = 0.1
 
 # basicVehicleStatus.mileage is a 16-bit field, so once the odometer passes
 # 6553.5 km it saturates at the uint16 maximum (65535) and stays there (#280).

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -20,8 +20,8 @@ from datetime import datetime, timezone
 from .const import (
     DOMAIN,
     LOGGER,
-    TEMP_SPIKE_MAX_JUMP_C,
-    TEMP_SPIKE_GUARD_WINDOW_S,
+    TEMP_SPIKE_BASE_TOLERANCE_C,
+    TEMP_SPIKE_MAX_RATE_C_PER_S,
     MILEAGE_UINT16_SATURATION,
     VEHICLE_REACHABILITY_AWAKE,
     VEHICLE_REACHABILITY_LIKELY_ASLEEP,
@@ -923,32 +923,46 @@ class SAICMGVehicleSensor(CoordinatorEntity, SensorEntity):
                                 )
                                 return self._last_valid_temperature.get(self._field)
                             computed = raw_value * self._factor
-                            # Transient-spike guard (#277): skip a SINGLE reading
-                            # that jumps implausibly fast, retaining the last
-                            # value. The next reading is always accepted, so a
-                            # genuine rapid change is only delayed one poll and
-                            # never permanently hidden.
+                            # Transient-spike guard (#277). Reject a reading
+                            # whose change from the last accepted value is
+                            # implausible for the time elapsed (rate-based, so it
+                            # also catches a small delta over a tiny interval —
+                            # e.g. two readings 15 ms apart walking 19°C -> 13°C).
+                            # Only ONE reading is skipped; the next is always
+                            # accepted, so a genuine change is delayed at most one
+                            # poll and never permanently hidden.
                             last = self._last_valid_temperature.get(self._field)
+                            if last is not None and computed == last:
+                                # Unchanged reading — return it without disturbing
+                                # the change timestamp (so "elapsed" measures time
+                                # since the value last actually changed, not since
+                                # this property was last evaluated).
+                                return computed
                             last_ts = self._last_valid_temperature_ts.get(self._field)
                             now = datetime.now(timezone.utc)
                             if (
                                 last is not None
                                 and last_ts is not None
                                 and not self._temp_spike_skipped.get(self._field)
-                                and (now - last_ts).total_seconds()
-                                <= TEMP_SPIKE_GUARD_WINDOW_S
-                                and abs(computed - last) > TEMP_SPIKE_MAX_JUMP_C
                             ):
-                                LOGGER.debug(
-                                    "Sensor %s: implausible temperature jump "
-                                    "%.1f°C→%.1f°C in %.0fs — skipping one reading",
-                                    self._name,
-                                    last,
-                                    computed,
-                                    (now - last_ts).total_seconds(),
+                                elapsed = max((now - last_ts).total_seconds(), 0.0)
+                                max_change = (
+                                    TEMP_SPIKE_BASE_TOLERANCE_C
+                                    + TEMP_SPIKE_MAX_RATE_C_PER_S * elapsed
                                 )
-                                self._temp_spike_skipped[self._field] = True
-                                return last
+                                if abs(computed - last) > max_change:
+                                    LOGGER.debug(
+                                        "Sensor %s: implausible temperature change "
+                                        "%.1f°C→%.1f°C in %.2fs (max %.1f°C) — "
+                                        "skipping one reading",
+                                        self._name,
+                                        last,
+                                        computed,
+                                        elapsed,
+                                        max_change,
+                                    )
+                                    self._temp_spike_skipped[self._field] = True
+                                    return last
                             self._temp_spike_skipped[self._field] = False
                             self._last_valid_temperature[self._field] = computed
                             self._last_valid_temperature_ts[self._field] = now

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -115,8 +115,8 @@ def _load_modules():
             CHARGING_CURRENT_FACTOR=0.05,
             CHARGING_VOLTAGE_FACTOR=0.25,
             DATA_100_DECIMAL_CORRECTION=0.01,
-            TEMP_SPIKE_MAX_JUMP_C=10,
-            TEMP_SPIKE_GUARD_WINDOW_S=300,
+            TEMP_SPIKE_BASE_TOLERANCE_C=3.0,
+            TEMP_SPIKE_MAX_RATE_C_PER_S=0.1,
             MILEAGE_UINT16_SATURATION=65535,
         )
         _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})


### PR DESCRIPTION
The fixed-threshold guard (>10C within 300s) checked each absolute delta independently, so two readings 15ms apart could walk past it in small steps even when the combined result was physically impossible — @jeffreyguilmot found interior temp accepting 19C then 13C (a 6C move in 15ms; 6C < the 10C threshold), leaving the sensor stuck on the bad value.

Replace with a rate-based check: reject a reading whose change exceeds BASE_TOLERANCE (3C) + MAX_RATE (0.1C/s) * seconds_elapsed. A 6C move in 15ms is now rejected (max ~3C) while real cooling/heat-soak over minutes passes. Also stop advancing the change-timestamp on unchanged readings, so 'elapsed' measures time since the value last actually changed rather than since the property was last evaluated. Skip-one behaviour retained.

Logic-tested: owner's 15ms case skipped (holds the correct value), big single-poll jumps caught, gradual heat-soak and deep cooling let through. Also updated test_india_soc.py's stub const.