### PR TITLE
fix(sensor): India BEV mileage no longer stuck unavailable (#283)

### DIFF
--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -693,6 +693,12 @@ class SAICMGMileageSensor(CoordinatorEntity, SensorEntity):
         For HEV vehicles, charging data is never fetched (the coordinator only
         fetches it for BEV/PHEV), so availability must not depend on it.
         Mileage for HEV comes from basicVehicleStatus which is always present.
+
+        Likewise, some backends (e.g. India) never fetch charging data at all
+        because they have no charging endpoint (INDIA_FEATURES omits
+        CHARGING_DATA). For those, a BEV/PHEV must not require charging data
+        either — the odometer comes from basicVehicleStatus, so requiring
+        charging would leave the sensor permanently unavailable (#283).
         """
         if self._last_valid_mileage is not None:
             return True
@@ -710,11 +716,17 @@ class SAICMGMileageSensor(CoordinatorEntity, SensorEntity):
                 and self.coordinator.data.get("status") is not None
             )
         elif self._vehicle_type in ["PHEV", "BEV"]:
-            return (
+            base_available = (
                 self.coordinator.last_update_success
                 and self.coordinator.data.get("status") is not None
-                and self.coordinator.data.get("charging") is not None
             )
+            # Only require charging data when the backend actually provides a
+            # charging endpoint. Backends without one (India) deliver the
+            # odometer via status alone, so gating on charging would deadlock
+            # the sensor into permanent unavailability (#283).
+            if not self.coordinator.backend_supports(Feature.CHARGING_DATA):
+                return base_available
+            return base_available and self.coordinator.data.get("charging") is not None
         else:
             return False
 


### PR DESCRIPTION
SAICMGMileageSensor.available required charging data for all BEV/PHEV, but India backends never fetch charging data (no charging endpoint; INDIA_FEATURES omits CHARGING_DATA). So an India BEV's Mileage sensor was permanently unavailable — HA then skips native_value, _last_valid_mileage never seeds, and it deadlocks unavailable forever, even though the odometer IS delivered (india.py maps odometer_km*10 -> basicVehicleStatus.mileage).

Relax the gate: BEV/PHEV require charging data only when the backend actually supports CHARGING_DATA; otherwise (India) fall back to status-only availability, like HEV. Global BEV/PHEV behaviour is unchanged (they support CHARGING_DATA). Pairs with the #280 overflow fix so India owners get a working odometer.

Logic-tested: India BEV now available; global BEV with/without charging data, retained-value, and HEV cases all unchanged.